### PR TITLE
chore(ci): add GitHub Actions workflow and husky pre-push hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, reopened, synchronize, ready_for_review ]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm install
+      
+      - name: Run type check
+        run: npm run test:types
+      
+      - name: Run lint
+        run: npm run lint

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+echo "Running pre-push checks..."
+npm run test:types
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-prettier": "^5.2.5",
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-native": "^5.0.0",
+        "husky": "^9.1.7",
         "jest": "^29.2.1",
         "jest-expo": "~52.0.6",
         "prettier": "^3.5.3",
@@ -9718,6 +9719,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
+    "test:types": "tsc --noEmit",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write ."

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
+    "prepare": "husky install",
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
@@ -56,6 +57,7 @@
     "eslint-plugin-prettier": "^5.2.5",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-native": "^5.0.0",
+    "husky": "^9.1.7",
     "jest": "^29.2.1",
     "jest-expo": "~52.0.6",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## 関連Issue
<!-- 関連するIssue番号やチケット番号を記述してください (例: Fixes #123, Relates to #456) -->
- #3

close #3

## 関連PR
<!-- 関連するPRを記述してください (例: Depends on #123, Blocks #456) -->
- なし

## 変更点
- GitHub Actionsを使用したCI設定を追加（PR作成時とmainブランチへのpush時に実行）
- huskyを使用したgit hooks（pre-push）の追加
- TypeScript型チェック用のnpmスクリプトを追加
- リンター実行の自動化

## 動作確認事項
<!-- 実施した動作確認の内容を箇条書きで記載してください -->
- CI設定が正しく動作することを確認（PRのチェック実行）
- pre-pushフックが正常に動作することを確認（型チェックとリントの実行）
- `npm run test:types`コマンドが正常に動作することを確認
