### PR TITLE
feat(questions): 問題解答のナビゲーションフローを実装

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,7 +13,9 @@ export default function HomeScreen() {
           <ThemedText type="subtitle">オタ力バトルしよう！</ThemedText>
         </View>
         <LevelDisplay />
-        <PrimaryButton onPress={() => router.push('/questions/group-selection')}>問題を解く</PrimaryButton>
+        <PrimaryButton onPress={() => router.push('/questions/group-selection')}>
+          問題を解く
+        </PrimaryButton>
         <SecondaryButton>問題を作成する</SecondaryButton>
       </SafeAreaView>
     </ScrollView>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,7 +4,7 @@ import { SecondaryButton } from '@/components/ui/button/SecondaryButton'
 import { ThemedText } from '@/components/ThemedText'
 import { Colors } from '@/constants/Colors'
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native'
-
+import { router } from 'expo-router'
 export default function HomeScreen() {
   return (
     <ScrollView style={styles.container}>
@@ -13,7 +13,7 @@ export default function HomeScreen() {
           <ThemedText type="subtitle">オタ力バトルしよう！</ThemedText>
         </View>
         <LevelDisplay />
-        <PrimaryButton>問題を解く</PrimaryButton>
+        <PrimaryButton onPress={() => router.push('/questions/group-selection')}>問題を解く</PrimaryButton>
         <SecondaryButton>問題を作成する</SecondaryButton>
       </SafeAreaView>
     </ScrollView>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,6 +31,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="questions" options={{ headerShown: true, headerBackTitle: 'トップへ戻る', headerTitle: '問題を解く' }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,7 +31,14 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="questions" options={{ headerShown: true, headerBackTitle: 'トップへ戻る', headerTitle: '問題を解く' }} />
+        <Stack.Screen
+          name="questions"
+          options={{
+            headerShown: true,
+            headerBackTitle: 'トップへ戻る',
+            headerTitle: '問題を解く',
+          }}
+        />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/app/questions/_layout.tsx
+++ b/app/questions/_layout.tsx
@@ -1,0 +1,34 @@
+import { Stack, Tabs } from 'expo-router'
+import { Platform } from 'react-native'
+
+import { HapticTab } from '@/components/HapticTab'
+import TabBarBackground from '@/components/ui/TabBarBackground'
+import { Colors } from '@/constants/Colors'
+import Entypo from '@expo/vector-icons/build/Entypo'
+import FontAwesome from '@expo/vector-icons/build/FontAwesome'
+import FontAwesome5 from '@expo/vector-icons/build/FontAwesome5'
+import Ionicons from '@expo/vector-icons/build/Ionicons'
+
+export default function TabLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen
+        name="group-selection"
+        options={{
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name="difficulty"
+        options={{
+          title: '難易度選択',
+          headerShown: true,
+        }}
+      />
+    </Stack>
+  )
+}

--- a/app/questions/_layout.tsx
+++ b/app/questions/_layout.tsx
@@ -1,13 +1,4 @@
-import { Stack, Tabs } from 'expo-router'
-import { Platform } from 'react-native'
-
-import { HapticTab } from '@/components/HapticTab'
-import TabBarBackground from '@/components/ui/TabBarBackground'
-import { Colors } from '@/constants/Colors'
-import Entypo from '@expo/vector-icons/build/Entypo'
-import FontAwesome from '@expo/vector-icons/build/FontAwesome'
-import FontAwesome5 from '@expo/vector-icons/build/FontAwesome5'
-import Ionicons from '@expo/vector-icons/build/Ionicons'
+import { Stack } from 'expo-router'
 
 export default function TabLayout() {
   return (

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -14,13 +14,12 @@ type Group = {
 export default function GroupSelectionScreen() {
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
 
-  // Mock data for groups
   const groups: Group[] = [
-    { id: '1', name: 'アニメ' },
-    { id: '2', name: 'マンガ' },
-    { id: '3', name: 'ゲーム' },
-    { id: '4', name: '映画' },
-    { id: '5', name: '音楽' },
+    { id: '1', name: 'BTS' },
+    { id: '2', name: 'BLACKPINK' },
+    { id: '3', name: 'TWICE' },
+    { id: '4', name: 'EXO' },
+    { id: '5', name: 'NCT' },
   ]
 
   const handleGroupSelect = (groupId: string) => {

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -83,6 +83,7 @@ const styles = StyleSheet.create({
   },
   groupButton: {
     paddingVertical: 16,
+    backgroundColor: Colors.secondary,
   },
   groupButtonText: {
     fontSize: 16,
@@ -100,9 +101,11 @@ const styles = StyleSheet.create({
     gap: 24,
   },
   selectedGroupButton: {
-    backgroundColor: Colors.tint,
+    // backgroundColor: Colors.tint,
+    borderWidth: 2,
+    borderColor: Colors.primary,
   },
   selectedGroupButtonText: {
-    color: Colors.white,
+    // color: Colors.white,
   },
 })

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -34,7 +34,7 @@ export default function GroupSelectionScreen() {
       router.push(`/questions/difficulty?groupId=${selectedGroup}`)
     }
   }
-
+    
   return (
     <ScrollView style={styles.container}>
       <SafeAreaView style={styles.safeAreaView}>

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -31,8 +31,8 @@ export default function GroupSelectionScreen() {
     if (selectedGroup) {
       // Navigate to the next screen with the selected group
       router.push({
-        pathname: "/questions/solve-problem",
-        params: { groupId: selectedGroup }
+        pathname: '/questions/solve-problem',
+        params: { groupId: selectedGroup },
       })
     }
   }

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -1,0 +1,115 @@
+import { StyleSheet, View, ScrollView, SafeAreaView } from 'react-native'
+import { useState } from 'react'
+import { router } from 'expo-router'
+
+import { ThemedText } from '@/components/ThemedText'
+import { PrimaryButton } from '@/components/ui/button/PrimaryButton'
+import { SecondaryButton } from '@/components/ui/button/SecondaryButton'
+import { Colors } from '@/constants/Colors'
+
+type Group = {
+  id: string
+  name: string
+}
+
+export default function GroupSelectionScreen() {
+  const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
+  
+  // Mock data for groups
+  const groups: Group[] = [
+    { id: '1', name: 'アニメ' },
+    { id: '2', name: 'マンガ' },
+    { id: '3', name: 'ゲーム' },
+    { id: '4', name: '映画' },
+    { id: '5', name: '音楽' },
+  ]
+
+  const handleGroupSelect = (groupId: string) => {
+    setSelectedGroup(groupId)
+  }
+
+  const handleContinue = () => {
+    if (selectedGroup) {
+      // Navigate to the next screen with the selected group
+      router.push(`/questions/difficulty?groupId=${selectedGroup}`)
+    }
+  }
+
+  return (
+    <ScrollView style={styles.container}>
+      <SafeAreaView style={styles.safeAreaView}>
+        <View style={styles.headerContainer}>
+          <ThemedText type="title">ジャンルを選択</ThemedText>
+          <ThemedText type="subtitle">挑戦したいジャンルを選んでください</ThemedText>
+        </View>
+        
+        <View style={styles.groupsContainer}>
+          {groups.map((group) => (
+            <SecondaryButton 
+              key={group.id}
+              onPress={() => handleGroupSelect(group.id)}
+              style={[
+                styles.groupButton,
+                selectedGroup === group.id && styles.selectedGroupButton
+              ]}
+            >
+              <ThemedText 
+                style={[
+                  styles.groupButtonText,
+                  selectedGroup === group.id && styles.selectedGroupButtonText
+                ]}
+              >
+                {group.name}
+              </ThemedText>
+            </SecondaryButton>
+          ))}
+        </View>
+        
+        <View style={styles.actionContainer}>
+          <PrimaryButton 
+            onPress={handleContinue}
+            disabled={!selectedGroup}
+          >
+            次へ進む
+          </PrimaryButton>
+        </View>
+      </SafeAreaView>
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.background,
+    flex: 1,
+    paddingHorizontal: 16,
+  },
+  safeAreaView: {
+    flex: 1,
+    gap: 24,
+    paddingVertical: 24,
+  },
+  headerContainer: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  groupsContainer: {
+    gap: 12,
+  },
+  groupButton: {
+    paddingVertical: 16,
+  },
+  selectedGroupButton: {
+    backgroundColor: Colors.tint,
+  },
+  groupButtonText: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  selectedGroupButtonText: {
+    color: '#FFFFFF',
+  },
+  actionContainer: {
+    marginTop: 16,
+  },
+})

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -83,11 +83,11 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.background,
     flex: 1,
     paddingHorizontal: 16,
+    paddingTop: 24,
   },
   safeAreaView: {
     flex: 1,
-    gap: 24,
-    paddingVertical: 24,
+    gap: 24
   },
   headerContainer: {
     alignItems: 'center',
@@ -107,7 +107,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   selectedGroupButtonText: {
-    color: '#FFFFFF',
+    color: Colors.white,
   },
   actionContainer: {
     marginTop: 16,

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -5,6 +5,7 @@ import { ThemedText } from '@/components/ThemedText'
 import { PrimaryButton } from '@/components/ui/button/PrimaryButton'
 import { SecondaryButton } from '@/components/ui/button/SecondaryButton'
 import { Colors } from '@/constants/Colors'
+import { router } from 'expo-router'
 
 type Group = {
   id: string
@@ -29,7 +30,10 @@ export default function GroupSelectionScreen() {
   const handleContinue = () => {
     if (selectedGroup) {
       // Navigate to the next screen with the selected group
-      // router.push(`/questions/difficulty?groupId=${selectedGroup}`)
+      router.push({
+        pathname: "/questions/solve-problem",
+        params: { groupId: selectedGroup }
+      })
     }
   }
 
@@ -55,7 +59,7 @@ export default function GroupSelectionScreen() {
 
         <View style={styles.actionContainer}>
           <PrimaryButton onPress={handleContinue} disabled={!selectedGroup}>
-            次へ進む
+            問題へ進む
           </PrimaryButton>
         </View>
       </SafeAreaView>

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -29,7 +29,7 @@ export default function GroupSelectionScreen() {
   const handleContinue = () => {
     if (selectedGroup) {
       // Navigate to the next screen with the selected group
-      //   router.push(`/questions/difficulty?groupId=${selectedGroup}`)
+      // router.push(`/questions/difficulty?groupId=${selectedGroup}`)
     }
   }
 
@@ -48,13 +48,7 @@ export default function GroupSelectionScreen() {
               onPress={() => handleGroupSelect(group.id)}
               style={[styles.groupButton, selectedGroup === group.id && styles.selectedGroupButton]}
             >
-              <ThemedText
-                style={[
-                  styles.groupButtonText,
-                ]}
-              >
-                {group.name}
-              </ThemedText>
+              <ThemedText style={styles.groupButtonText}>{group.name}</ThemedText>
             </SecondaryButton>
           ))}
         </View>
@@ -80,8 +74,8 @@ const styles = StyleSheet.create({
     paddingTop: 24,
   },
   groupButton: {
-    paddingVertical: 16,
     backgroundColor: Colors.secondary,
+    paddingVertical: 16,
   },
   groupButtonText: {
     fontSize: 16,
@@ -99,7 +93,7 @@ const styles = StyleSheet.create({
     gap: 24,
   },
   selectedGroupButton: {
-    borderWidth: 2,
     borderColor: Colors.primary,
+    borderWidth: 2,
   },
 })

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -1,5 +1,5 @@
-import { StyleSheet, View, ScrollView, SafeAreaView } from 'react-native'
 import { useState } from 'react'
+import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native'
 
 import { ThemedText } from '@/components/ThemedText'
 import { PrimaryButton } from '@/components/ui/button/PrimaryButton'
@@ -52,7 +52,6 @@ export default function GroupSelectionScreen() {
               <ThemedText
                 style={[
                   styles.groupButtonText,
-                  selectedGroup === group.id && styles.selectedGroupButtonText,
                 ]}
               >
                 {group.name}
@@ -101,11 +100,7 @@ const styles = StyleSheet.create({
     gap: 24,
   },
   selectedGroupButton: {
-    // backgroundColor: Colors.tint,
     borderWidth: 2,
     borderColor: Colors.primary,
-  },
-  selectedGroupButtonText: {
-    // color: Colors.white,
   },
 })

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -1,6 +1,5 @@
 import { StyleSheet, View, ScrollView, SafeAreaView } from 'react-native'
 import { useState } from 'react'
-import { router } from 'expo-router'
 
 import { ThemedText } from '@/components/ThemedText'
 import { PrimaryButton } from '@/components/ui/button/PrimaryButton'
@@ -14,7 +13,7 @@ type Group = {
 
 export default function GroupSelectionScreen() {
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
-  
+
   // Mock data for groups
   const groups: Group[] = [
     { id: '1', name: 'アニメ' },
@@ -31,10 +30,10 @@ export default function GroupSelectionScreen() {
   const handleContinue = () => {
     if (selectedGroup) {
       // Navigate to the next screen with the selected group
-    //   router.push(`/questions/difficulty?groupId=${selectedGroup}`)
+      //   router.push(`/questions/difficulty?groupId=${selectedGroup}`)
     }
   }
-    
+
   return (
     <ScrollView style={styles.container}>
       <SafeAreaView style={styles.safeAreaView}>
@@ -42,21 +41,18 @@ export default function GroupSelectionScreen() {
           <ThemedText type="title">ジャンルを選択</ThemedText>
           <ThemedText type="subtitle">挑戦したいジャンルを選んでください</ThemedText>
         </View>
-        
+
         <View style={styles.groupsContainer}>
           {groups.map((group) => (
-            <SecondaryButton 
+            <SecondaryButton
               key={group.id}
               onPress={() => handleGroupSelect(group.id)}
-              style={[
-                styles.groupButton,
-                selectedGroup === group.id && styles.selectedGroupButton
-              ]}
+              style={[styles.groupButton, selectedGroup === group.id && styles.selectedGroupButton]}
             >
-              <ThemedText 
+              <ThemedText
                 style={[
                   styles.groupButtonText,
-                  selectedGroup === group.id && styles.selectedGroupButtonText
+                  selectedGroup === group.id && styles.selectedGroupButtonText,
                 ]}
               >
                 {group.name}
@@ -64,12 +60,9 @@ export default function GroupSelectionScreen() {
             </SecondaryButton>
           ))}
         </View>
-        
+
         <View style={styles.actionContainer}>
-          <PrimaryButton 
-            onPress={handleContinue}
-            disabled={!selectedGroup}
-          >
+          <PrimaryButton onPress={handleContinue} disabled={!selectedGroup}>
             次へ進む
           </PrimaryButton>
         </View>
@@ -79,37 +72,37 @@ export default function GroupSelectionScreen() {
 }
 
 const styles = StyleSheet.create({
+  actionContainer: {
+    marginTop: 16,
+  },
   container: {
     backgroundColor: Colors.background,
     flex: 1,
     paddingHorizontal: 16,
     paddingTop: 24,
   },
-  safeAreaView: {
-    flex: 1,
-    gap: 24
-  },
-  headerContainer: {
-    alignItems: 'center',
-    gap: 8,
-  },
-  groupsContainer: {
-    gap: 12,
-  },
   groupButton: {
     paddingVertical: 16,
-  },
-  selectedGroupButton: {
-    backgroundColor: Colors.tint,
   },
   groupButtonText: {
     fontSize: 16,
     textAlign: 'center',
   },
+  groupsContainer: {
+    gap: 12,
+  },
+  headerContainer: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  safeAreaView: {
+    flex: 1,
+    gap: 24,
+  },
+  selectedGroupButton: {
+    backgroundColor: Colors.tint,
+  },
   selectedGroupButtonText: {
     color: Colors.white,
-  },
-  actionContainer: {
-    marginTop: 16,
   },
 })

--- a/app/questions/group-selection.tsx
+++ b/app/questions/group-selection.tsx
@@ -31,7 +31,7 @@ export default function GroupSelectionScreen() {
   const handleContinue = () => {
     if (selectedGroup) {
       // Navigate to the next screen with the selected group
-      router.push(`/questions/difficulty?groupId=${selectedGroup}`)
+    //   router.push(`/questions/difficulty?groupId=${selectedGroup}`)
     }
   }
     

--- a/app/questions/solve-problem.tsx
+++ b/app/questions/solve-problem.tsx
@@ -6,7 +6,7 @@ import { PrimaryButton } from '@/components/ui/button/PrimaryButton'
 import { Colors } from '@/constants/Colors'
 
 export default function SolveProblemScreen() {
-  const [answer, setAnswer] = useState('')
+  const [answer] = useState('')
 
   const handleSubmit = () => {
     // 解答送信処理
@@ -22,9 +22,7 @@ export default function SolveProblemScreen() {
         </View>
 
         <View style={styles.questionContainer}>
-          <ThemedText style={styles.questionText}>
-            ここに問題文が表示されます
-          </ThemedText>
+          <ThemedText style={styles.questionText}>ここに問題文が表示されます</ThemedText>
         </View>
 
         <View style={styles.answerContainer}>
@@ -33,9 +31,7 @@ export default function SolveProblemScreen() {
         </View>
 
         <View style={styles.actionContainer}>
-          <PrimaryButton onPress={handleSubmit}>
-            解答を送信
-          </PrimaryButton>
+          <PrimaryButton onPress={handleSubmit}>解答を送信</PrimaryButton>
         </View>
       </SafeAreaView>
     </ScrollView>

--- a/app/questions/solve-problem.tsx
+++ b/app/questions/solve-problem.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native'
+
+import { ThemedText } from '@/components/ThemedText'
+import { PrimaryButton } from '@/components/ui/button/PrimaryButton'
+import { Colors } from '@/constants/Colors'
+
+export default function SolveProblemScreen() {
+  const [answer, setAnswer] = useState('')
+
+  const handleSubmit = () => {
+    // 解答送信処理
+    console.log('Submitted answer:', answer)
+  }
+
+  return (
+    <ScrollView style={styles.container}>
+      <SafeAreaView style={styles.safeAreaView}>
+        <View style={styles.headerContainer}>
+          <ThemedText type="title">問題を解く</ThemedText>
+          <ThemedText type="subtitle">以下の問題に解答してください</ThemedText>
+        </View>
+
+        <View style={styles.questionContainer}>
+          <ThemedText style={styles.questionText}>
+            ここに問題文が表示されます
+          </ThemedText>
+        </View>
+
+        <View style={styles.answerContainer}>
+          <ThemedText style={styles.answerLabel}>解答:</ThemedText>
+          {/* 解答入力フィールドをここに追加 */}
+        </View>
+
+        <View style={styles.actionContainer}>
+          <PrimaryButton onPress={handleSubmit}>
+            解答を送信
+          </PrimaryButton>
+        </View>
+      </SafeAreaView>
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  actionContainer: {
+    marginTop: 16,
+  },
+  answerContainer: {
+    marginTop: 24,
+  },
+  answerLabel: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  container: {
+    backgroundColor: Colors.background,
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 24,
+  },
+  headerContainer: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  questionContainer: {
+    marginTop: 24,
+  },
+  questionText: {
+    fontSize: 18,
+    lineHeight: 24,
+  },
+  safeAreaView: {
+    flex: 1,
+    gap: 24,
+  },
+})

--- a/components/ui/button/PrimaryButton.tsx
+++ b/components/ui/button/PrimaryButton.tsx
@@ -1,14 +1,13 @@
 import { Colors } from '@/constants/Colors'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
-type PrimaryButtonProps = {
+type PrimaryButtonProps = React.ComponentProps<typeof TouchableOpacity> & {
   children: React.ReactNode
-  onPress?: () => void
 }
 
-export function PrimaryButton({ children, onPress }: PrimaryButtonProps) {
+export function PrimaryButton({ children, ...props }: PrimaryButtonProps) {
   return (
-    <TouchableOpacity style={styles.button} onPress={onPress}>
+    <TouchableOpacity style={[styles.button, props.style]} {...props}>
       <View style={styles.buttonContent}>
         {typeof children === 'string' ? (
           <Text style={styles.buttonText}>{children}</Text>

--- a/components/ui/button/SecondaryButton.tsx
+++ b/components/ui/button/SecondaryButton.tsx
@@ -1,14 +1,13 @@
 import { Colors } from '@/constants/Colors'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
-type SecondaryButtonProps = {
+type SecondaryButtonProps = React.ComponentProps<typeof TouchableOpacity> & {
   children: React.ReactNode
-  onPress?: () => void
 }
 
-export function SecondaryButton({ children, onPress }: SecondaryButtonProps) {
+export function SecondaryButton({ children, ...props }: SecondaryButtonProps) {
   return (
-    <TouchableOpacity style={styles.button} onPress={onPress}>
+    <TouchableOpacity style={[styles.button, props.style]} {...props}>
       <View style={styles.buttonContent}>
         {typeof children === 'string' ? (
           <Text style={styles.buttonText}>{children}</Text>


### PR DESCRIPTION
## 関連Issue

close #11 
- #11

## 関連PR

-

## 変更点

- トップ画面の「問題を解く」ボタンに遷移機能を追加
- 問題を解くための画面遷移構造を実装
  - `app/questions/_layout.tsx`: 問題関連画面のレイアウト設定
  - `app/questions/group-selection.tsx`: ジャンル選択画面の実装
  - `app/questions/solve-problem.tsx`: 問題解答画面の実装
- ボタンコンポーネントの拡張
  - `PrimaryButton`と`SecondaryButton`にstyle propを追加
  - TouchableOpacityのpropsを継承するように型定義を修正


## 動作確認事項

- トップ画面から「問題を解く」ボタンをタップして問題選択画面に遷移すること
- グループ選択画面でグループを選択して「問題へ進む」ボタンがタップできること
- 選択したグループの問題が表示されること
- 異なるグループを選択した際に表示が切り替わること
