### PR TITLE
chore(dev): pre-pushフックの改善とデータベース設計ドキュメントの追加

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 echo "Running pre-push checks..."
 npm run test:types
 npm run lint
-npm run format
+npm run format:check

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import { ThemedText } from '@/components/ThemedText'
 import { Colors } from '@/constants/Colors'
 import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native'
 import { router } from 'expo-router'
+
 export default function HomeScreen() {
   return (
     <ScrollView style={styles.container}>

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,90 @@
+# データベーススキーマ
+
+## エンティティ関連図
+
+```mermaid
+erDiagram
+    group_category {
+        int group_category_id PK
+        string category_name
+    }
+    idol_group {
+        int idol_group_id PK
+        int group_category_id FK
+        string idol_group_name
+        text thumbnail_image
+    }
+    app_user {
+        int app_user_id PK
+        string line_account_id
+        string user_name
+    }
+    otaku_layer {
+        int otaku_layer_id PK
+        string layer_name
+        int min_score
+        int max_score
+    }
+    user_total_otaku_score {
+        int user_total_otaku_score_id PK
+        int app_user_id FK
+        int total_otaku_score
+        int otaku_layer_id FK
+    }
+    user_idol_group_score {
+        int user_idol_group_score_id PK
+        int app_user_id FK
+        int idol_group_id FK
+        int otaku_score
+        int otaku_layer_id FK
+    }
+    quiz_difficulty {
+        int quiz_difficulty_id PK
+        string difficulty_name
+    }
+    quiz_question {
+        int quiz_question_id PK
+        int idol_group_id FK
+        int quiz_difficulty_id FK
+        text question_text
+        string choice1
+        string choice2
+        string choice3
+        string choice4
+        int correct_choice
+        text explanation
+    }
+    user_quiz_answer {
+        int user_quiz_answer_id PK
+        int app_user_id FK
+        int quiz_question_id FK
+        int selected_choice
+        boolean is_correct
+        datetime answered_at
+    }
+
+    %% リレーション定義
+    group_category ||--|{ idol_group : "has many"
+    idol_group }|--|| group_category : "belongs to"
+
+    app_user ||--|| user_total_otaku_score : "has one (total)"
+    user_total_otaku_score }|--|| app_user : "belongs to"
+    user_total_otaku_score }|--|| otaku_layer : "belongs to"
+
+    app_user ||--|{ user_idol_group_score : "has many (per group)"
+    idol_group ||--|{ user_idol_group_score : "has many"
+    otaku_layer ||--|{ user_idol_group_score : "has many"
+    user_idol_group_score }|--|| app_user : "belongs to"
+    user_idol_group_score }|--|| idol_group : "belongs to"
+    user_idol_group_score }|--|| otaku_layer : "belongs to"
+
+    idol_group ||--|{ quiz_question : "has many"
+    quiz_difficulty ||--|{ quiz_question : "has many"
+    quiz_question }|--|| idol_group : "belongs to"
+    quiz_question }|--|| quiz_difficulty : "belongs to"
+
+    app_user ||--|{ user_quiz_answer : "has many"
+    quiz_question ||--|{ user_quiz_answer : "has many"
+    user_quiz_answer }|--|| app_user : "belongs to"
+    user_quiz_answer }|--|| quiz_question : "belongs to"
+```

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -16,7 +16,7 @@ erDiagram
     }
     app_user {
         int app_user_id PK "NOT NULL"
-        uuid supabase_uuid "NOT NULL, Supabaseで発行されたUUID"
+        uuid supabase_uuid "NOT NULL"
         string line_account_id "NOT NULL"
     }
     user_profile {

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -118,51 +118,51 @@ erDiagram
     %% Relationship Definitions
     group_category ||--|{ idol_group : "has many"
     idol_group }|--|| group_category : "belongs to"
-    
+
     app_user ||--|| user_profile : "has one profile"
     user_profile }|--|| app_user : "belongs to"
-    
+
     user_profile }|--|| total_otaku_layer : "belongs to (total layer)"
     total_otaku_layer ||--|{ user_profile : "has many"
-    
+
     app_user ||--|{ user_idol_group_score : "has many (per group score)"
     user_idol_group_score }|--|| app_user : "belongs to"
     idol_group ||--|{ user_idol_group_score : "has many"
     user_idol_group_score }|--|| idol_group : "belongs to"
     user_idol_group_score }|--|| group_otaku_layer : "belongs to (group layer)"
     group_otaku_layer ||--|{ user_idol_group_score : "has many"
-    
+
     idol_group ||--|{ quiz_question : "has many"
     quiz_difficulty ||--|{ quiz_question : "has many"
     quiz_question }|--|| idol_group : "belongs to"
     quiz_question }|--|| quiz_difficulty : "belongs to"
-    
+
     app_user ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| app_user : "belongs to"
     quiz_question ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| quiz_question : "belongs to"
-    
+
     app_user ||--|{ ranking_total : "has one total ranking entry"
     ranking_total }|--|| app_user : "belongs to"
-    
+
     app_user ||--|{ ranking_group : "has many group ranking entries"
     ranking_group }|--|| app_user : "belongs to"
     idol_group ||--|{ ranking_group : "has many"
     ranking_group }|--|| idol_group : "belongs to"
-    
+
     app_user ||--|{ event : "creates"
     event }|--|| app_user : "created by"
-    
+
     event ||--|{ event_participation : "has many"
     event_participation }|--|| event : "belongs to"
     app_user ||--|{ event_participation : "participates in"
     event_participation }|--|| app_user : "belongs to"
-    
+
     event ||--|{ event_group_participation : "has many participating groups"
     event_group_participation }|--|| event : "belongs to event"
     idol_group ||--|{ event_group_participation : "has many event participations"
     event_group_participation }|--|| idol_group : "belongs to idol group"
-    
+
     app_user ||--|{ monthly_score_history : "has many monthly score entries"
     monthly_score_history }|--|| app_user : "belongs to"
 ```

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -111,46 +111,46 @@ erDiagram
     %% Relationship Definitions
     group_category ||--|{ idol_group : "has many"
     idol_group }|--|| group_category : "belongs to"
-    
+
     app_user ||--|| user_profile : "has one profile"
     user_profile }|--|| app_user : "belongs to"
-    
+
     user_profile }|--|| total_otaku_layer : "belongs to (total layer)"
     total_otaku_layer ||--|{ user_profile : "has many"
-    
+
     app_user ||--|{ user_idol_group_score : "has many (per group score)"
     user_idol_group_score }|--|| app_user : "belongs to"
     idol_group ||--|{ user_idol_group_score : "has many"
     user_idol_group_score }|--|| idol_group : "belongs to"
     user_idol_group_score }|--|| group_otaku_layer : "belongs to (group layer)"
     group_otaku_layer ||--|{ user_idol_group_score : "has many"
-    
+
     idol_group ||--|{ quiz_question : "has many"
     quiz_difficulty ||--|{ quiz_question : "has many"
     quiz_question }|--|| idol_group : "belongs to"
     quiz_question }|--|| quiz_difficulty : "belongs to"
-    
+
     app_user ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| app_user : "belongs to"
     quiz_question ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| quiz_question : "belongs to"
-    
+
     app_user ||--|{ ranking_total : "has one total ranking entry"
     ranking_total }|--|| app_user : "belongs to"
-    
+
     app_user ||--|{ ranking_group : "has many group ranking entries"
     ranking_group }|--|| app_user : "belongs to"
     idol_group ||--|{ ranking_group : "has many"
     ranking_group }|--|| idol_group : "belongs to"
-    
+
     app_user ||--|{ event : "creates"
     event }|--|| app_user : "created by"
-    
+
     event ||--|{ event_participation : "has many"
     event_participation }|--|| event : "belongs to"
     app_user ||--|{ event_participation : "participates in"
     event_participation }|--|| app_user : "belongs to"
-    
+
     event ||--|{ event_group_participation : "has many participating groups"
     event_group_participation }|--|| event : "belongs to event"
     idol_group ||--|{ event_group_participation : "has many event participations"

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -25,9 +25,16 @@ erDiagram
         string user_name
         int total_otaku_score "総合オタク力"
         int remaining_drop "所持中のドロップ数"
+        int total_otaku_layer_id FK "総合オタクレイヤー"
     }
-    otaku_layer {
-        int otaku_layer_id PK
+    total_otaku_layer {
+        int total_otaku_layer_id PK
+        string layer_name
+        int min_score
+        int max_score
+    }
+    group_otaku_layer {
+        int group_otaku_layer_id PK
         string layer_name
         int min_score
         int max_score
@@ -37,7 +44,7 @@ erDiagram
         int app_user_id FK
         int idol_group_id FK
         int otaku_score
-        int otaku_layer_id FK
+        int group_otaku_layer_id FK "グループ別オタクレイヤー"
     }
     quiz_difficulty {
         int quiz_difficulty_id PK
@@ -108,12 +115,15 @@ erDiagram
     app_user ||--|| user_profile : "has one profile"
     user_profile }|--|| app_user : "belongs to"
 
+    user_profile }|--|| total_otaku_layer : "belongs to (total layer)"
+    total_otaku_layer ||--|{ user_profile : "has many"
+
     app_user ||--|{ user_idol_group_score : "has many (per group score)"
     user_idol_group_score }|--|| app_user : "belongs to"
     idol_group ||--|{ user_idol_group_score : "has many"
     user_idol_group_score }|--|| idol_group : "belongs to"
-    otaku_layer ||--|{ user_idol_group_score : "has many"
-    user_idol_group_score }|--|| otaku_layer : "belongs to"
+    user_idol_group_score }|--|| group_otaku_layer : "belongs to (group layer)"
+    group_otaku_layer ||--|{ user_idol_group_score : "has many"
 
     idol_group ||--|{ quiz_question : "has many"
     quiz_difficulty ||--|{ quiz_question : "has many"

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -5,106 +5,154 @@
 ```mermaid
 erDiagram
     group_category {
-        int group_category_id PK NOT NULL
-        string category_name NOT NULL
+        int group_category_id PK "NOT NULL"
+        string category_name "NOT NULL"
     }
     idol_group {
-        int idol_group_id PK NOT NULL
-        int group_category_id FK NOT NULL
-        string idol_group_name NOT NULL
-        text thumbnail_image NULL
+        int idol_group_id PK "NOT NULL"
+        int group_category_id FK "NOT NULL"
+        string idol_group_name "NOT NULL"
+        text thumbnail_image "NULL allowed"
     }
     app_user {
-        int app_user_id PK NOT NULL
-        uuid supabase_uuid NOT NULL "Supabaseで発行されたUUID"
-        string line_account_id NOT NULL
+        int app_user_id PK "NOT NULL"
+        uuid supabase_uuid "NOT NULL, Supabaseで発行されたUUID"
+        string line_account_id "NOT NULL"
     }
     user_profile {
-        int user_profile_id PK NOT NULL
-        int app_user_id FK NOT NULL
-        string user_name NOT NULL
-        int total_otaku_score NOT NULL "総合オタク力"
-        int remaining_drop NOT NULL "所持中のドロップ数"
-        int total_otaku_layer_id FK NOT NULL "総合オタクレイヤー"
+        int user_profile_id PK "NOT NULL"
+        int app_user_id FK "NOT NULL"
+        string user_name "NOT NULL"
+        int total_otaku_score "NOT NULL, 総合オタク力"
+        int remaining_drop "NOT NULL, 所持中のドロップ数"
+        int total_otaku_layer_id FK "NOT NULL, 総合オタクレイヤー"
     }
     total_otaku_layer {
-        int total_otaku_layer_id PK NOT NULL
-        string layer_name NOT NULL
-        int min_score NOT NULL
-        int max_score NOT NULL
+        int total_otaku_layer_id PK "NOT NULL"
+        string layer_name "NOT NULL"
+        int min_score "NOT NULL"
+        int max_score "NOT NULL"
     }
     group_otaku_layer {
-        int group_otaku_layer_id PK NOT NULL
-        string layer_name NOT NULL
-        int min_score NOT NULL
-        int max_score NOT NULL
+        int group_otaku_layer_id PK "NOT NULL"
+        string layer_name "NOT NULL"
+        int min_score "NOT NULL"
+        int max_score "NOT NULL"
     }
     user_idol_group_score {
-        int user_idol_group_score_id PK NOT NULL
-        int app_user_id FK NOT NULL
-        int idol_group_id FK NOT NULL
-        int otaku_score NOT NULL
-        int group_otaku_layer_id FK NOT NULL "グループ別オタクレイヤー"
+        int user_idol_group_score_id PK "NOT NULL"
+        int app_user_id FK "NOT NULL"
+        int idol_group_id FK "NOT NULL"
+        int otaku_score "NOT NULL"
+        int group_otaku_layer_id FK "NOT NULL, グループ別オタクレイヤー"
     }
     quiz_difficulty {
-        int quiz_difficulty_id PK NOT NULL
-        string difficulty_name NOT NULL
+        int quiz_difficulty_id PK "NOT NULL"
+        string difficulty_name "NOT NULL"
     }
     quiz_question {
-        int quiz_question_id PK NOT NULL
-        int idol_group_id FK NOT NULL
-        int quiz_difficulty_id FK NOT NULL
-        text question_text NOT NULL
-        string choice1 NOT NULL
-        string choice2 NOT NULL
-        string choice3 NOT NULL
-        string choice4 NOT NULL
-        int correct_choice NOT NULL
-        text explanation NOT NULL
+        int quiz_question_id PK "NOT NULL"
+        int idol_group_id FK "NOT NULL"
+        int quiz_difficulty_id FK "NOT NULL"
+        text question_text "NOT NULL"
+        string choice1 "NOT NULL"
+        string choice2 "NOT NULL"
+        string choice3 "NOT NULL"
+        string choice4 "NOT NULL"
+        int correct_choice "NOT NULL"
+        text explanation "NOT NULL"
     }
     user_quiz_answer {
-        int user_quiz_answer_id PK NOT NULL
-        int app_user_id FK NOT NULL
-        int quiz_question_id FK NOT NULL
-        int selected_choice NOT NULL
-        boolean is_correct NOT NULL
-        datetime answered_at NOT NULL
+        int user_quiz_answer_id PK "NOT NULL"
+        int app_user_id FK "NOT NULL"
+        int quiz_question_id FK "NOT NULL"
+        int selected_choice "NOT NULL"
+        boolean is_correct "NOT NULL"
+        datetime answered_at "NOT NULL"
     }
     ranking_total {
-        int ranking_total_id PK NOT NULL
-        int app_user_id FK NOT NULL
-        int display_rank NOT NULL "実際の総合順位"
-        int display_score NOT NULL "バッチ計算時点の総合スコア"
-        datetime updated_at NOT NULL
+        int ranking_total_id PK "NOT NULL"
+        int app_user_id FK "NOT NULL"
+        int display_rank "NOT NULL, 実際の総合順位"
+        int display_score "NOT NULL, バッチ計算時点の総合スコア"
+        datetime updated_at "NOT NULL"
     }
     ranking_group {
-        int ranking_group_id PK NOT NULL
-        int app_user_id FK NOT NULL
-        int idol_group_id FK NOT NULL
-        int display_rank NOT NULL "実際のグループ順位"
-        int display_score NOT NULL "バッチ計算時点のグループ別スコア"
-        datetime updated_at NOT NULL
+        int ranking_group_id PK "NOT NULL"
+        int app_user_id FK "NOT NULL"
+        int idol_group_id FK "NOT NULL"
+        int display_rank "NOT NULL, 実際のグループ順位"
+        int display_score "NOT NULL, バッチ計算時点のグループ別スコア"
+        datetime updated_at "NOT NULL"
     }
     event {
-        int event_id PK NOT NULL
-        int created_by FK NOT NULL "イベント作成者(app_user_id)"
-        string event_name NOT NULL
-        text event_description NOT NULL
-        string location NOT NULL
-        datetime event_date NOT NULL
-        datetime created_at NOT NULL
-        datetime updated_at NOT NULL
+        int event_id PK "NOT NULL"
+        int created_by FK "NOT NULL, イベント作成者(app_user_id)"
+        string event_name "NOT NULL"
+        text event_description "NOT NULL"
+        string location "NOT NULL"
+        datetime event_date "NOT NULL"
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
     }
     event_participation {
-        int event_participation_id PK NOT NULL
-        int event_id FK NOT NULL
-        int app_user_id FK NOT NULL
-        datetime joined_at NOT NULL
+        int event_participation_id PK "NOT NULL"
+        int event_id FK "NOT NULL"
+        int app_user_id FK "NOT NULL"
+        datetime joined_at "NOT NULL"
     }
     event_group_participation {
-        int event_group_participation_id PK NOT NULL
-        int event_id FK NOT NULL
-        int idol_group_id FK NOT NULL
-        datetime registered_at NOT NULL "グループ参加登録日時"
+        int event_group_participation_id PK "NOT NULL"
+        int event_id FK "NOT NULL"
+        int idol_group_id FK "NOT NULL"
+        datetime registered_at "NOT NULL, グループ参加登録日時"
     }
+
+    %% Relationship Definitions
+    group_category ||--|{ idol_group : "has many"
+    idol_group }|--|| group_category : "belongs to"
+    
+    app_user ||--|| user_profile : "has one profile"
+    user_profile }|--|| app_user : "belongs to"
+    
+    user_profile }|--|| total_otaku_layer : "belongs to (total layer)"
+    total_otaku_layer ||--|{ user_profile : "has many"
+    
+    app_user ||--|{ user_idol_group_score : "has many (per group score)"
+    user_idol_group_score }|--|| app_user : "belongs to"
+    idol_group ||--|{ user_idol_group_score : "has many"
+    user_idol_group_score }|--|| idol_group : "belongs to"
+    user_idol_group_score }|--|| group_otaku_layer : "belongs to (group layer)"
+    group_otaku_layer ||--|{ user_idol_group_score : "has many"
+    
+    idol_group ||--|{ quiz_question : "has many"
+    quiz_difficulty ||--|{ quiz_question : "has many"
+    quiz_question }|--|| idol_group : "belongs to"
+    quiz_question }|--|| quiz_difficulty : "belongs to"
+    
+    app_user ||--|{ user_quiz_answer : "has many"
+    user_quiz_answer }|--|| app_user : "belongs to"
+    quiz_question ||--|{ user_quiz_answer : "has many"
+    user_quiz_answer }|--|| quiz_question : "belongs to"
+    
+    app_user ||--|{ ranking_total : "has one total ranking entry"
+    ranking_total }|--|| app_user : "belongs to"
+    
+    app_user ||--|{ ranking_group : "has many group ranking entries"
+    ranking_group }|--|| app_user : "belongs to"
+    idol_group ||--|{ ranking_group : "has many"
+    ranking_group }|--|| idol_group : "belongs to"
+    
+    app_user ||--|{ event : "creates"
+    event }|--|| app_user : "created by"
+    
+    event ||--|{ event_participation : "has many"
+    event_participation }|--|| event : "belongs to"
+    app_user ||--|{ event_participation : "participates in"
+    event_participation }|--|| app_user : "belongs to"
+    
+    event ||--|{ event_group_participation : "has many participating groups"
+    event_group_participation }|--|| event : "belongs to event"
+    idol_group ||--|{ event_group_participation : "has many event participations"
+    event_group_participation }|--|| idol_group : "belongs to idol group"
 ```

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -16,20 +16,21 @@ erDiagram
     }
     app_user {
         int app_user_id PK
+        uuid supabase_uuid "Supabaseで発行されたUUID"
         string line_account_id
+    }
+    user_profile {
+        int user_profile_id PK
+        int app_user_id FK
         string user_name
+        int total_otaku_score "総合オタク力"
+        int remaining_drop "所持中のドロップ数"
     }
     otaku_layer {
         int otaku_layer_id PK
         string layer_name
         int min_score
         int max_score
-    }
-    user_total_otaku_score {
-        int user_total_otaku_score_id PK
-        int app_user_id FK
-        int total_otaku_score
-        int otaku_layer_id FK
     }
     user_idol_group_score {
         int user_idol_group_score_id PK
@@ -62,20 +63,56 @@ erDiagram
         boolean is_correct
         datetime answered_at
     }
+    ranking_total {
+        int ranking_total_id PK
+        int app_user_id FK
+        int display_rank "実際の総合順位"
+        int display_score "バッチ計算時点の総合スコア"
+        datetime updated_at
+    }
+    ranking_group {
+        int ranking_group_id PK
+        int app_user_id FK
+        int idol_group_id FK
+        int display_rank "実際のグループ順位"
+        int display_score "バッチ計算時点のグループ別スコア"
+        datetime updated_at
+    }
+    event {
+        int event_id PK
+        int created_by FK "イベント作成者(app_user_id)"
+        string event_name
+        text event_description
+        string location
+        datetime event_date
+        datetime created_at
+        datetime updated_at
+    }
+    event_participation {
+        int event_participation_id PK
+        int event_id FK
+        int app_user_id FK
+        datetime joined_at
+    }
+    event_group_participation {
+        int event_group_participation_id PK
+        int event_id FK
+        int idol_group_id FK
+        datetime registered_at "グループ参加登録日時"
+    }
 
     %% リレーション定義
     group_category ||--|{ idol_group : "has many"
     idol_group }|--|| group_category : "belongs to"
 
-    app_user ||--|| user_total_otaku_score : "has one (total)"
-    user_total_otaku_score }|--|| app_user : "belongs to"
-    user_total_otaku_score }|--|| otaku_layer : "belongs to"
+    app_user ||--|| user_profile : "has one profile"
+    user_profile }|--|| app_user : "belongs to"
 
-    app_user ||--|{ user_idol_group_score : "has many (per group)"
-    idol_group ||--|{ user_idol_group_score : "has many"
-    otaku_layer ||--|{ user_idol_group_score : "has many"
+    app_user ||--|{ user_idol_group_score : "has many (per group score)"
     user_idol_group_score }|--|| app_user : "belongs to"
+    idol_group ||--|{ user_idol_group_score : "has many"
     user_idol_group_score }|--|| idol_group : "belongs to"
+    otaku_layer ||--|{ user_idol_group_score : "has many"
     user_idol_group_score }|--|| otaku_layer : "belongs to"
 
     idol_group ||--|{ quiz_question : "has many"
@@ -84,7 +121,28 @@ erDiagram
     quiz_question }|--|| quiz_difficulty : "belongs to"
 
     app_user ||--|{ user_quiz_answer : "has many"
-    quiz_question ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| app_user : "belongs to"
+    quiz_question ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| quiz_question : "belongs to"
+
+    app_user ||--|{ ranking_total : "has one total ranking entry"
+    ranking_total }|--|| app_user : "belongs to"
+
+    app_user ||--|{ ranking_group : "has many group ranking entries"
+    ranking_group }|--|| app_user : "belongs to"
+    idol_group ||--|{ ranking_group : "has many"
+    ranking_group }|--|| idol_group : "belongs to"
+
+    app_user ||--|{ event : "creates"
+    event }|--|| app_user : "created by"
+
+    event ||--|{ event_participation : "has many"
+    event_participation }|--|| event : "belongs to"
+    app_user ||--|{ event_participation : "participates in"
+    event_participation }|--|| app_user : "belongs to"
+
+    event ||--|{ event_group_participation : "has many participating groups"
+    event_group_participation }|--|| event : "belongs to event"
+    idol_group ||--|{ event_group_participation : "has many event participations"
+    event_group_participation }|--|| idol_group : "belongs to idol group"
 ```

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -5,154 +5,106 @@
 ```mermaid
 erDiagram
     group_category {
-        int group_category_id PK
-        string category_name
+        int group_category_id PK NOT NULL
+        string category_name NOT NULL
     }
     idol_group {
-        int idol_group_id PK
-        int group_category_id FK
-        string idol_group_name
-        text thumbnail_image
+        int idol_group_id PK NOT NULL
+        int group_category_id FK NOT NULL
+        string idol_group_name NOT NULL
+        text thumbnail_image NULL
     }
     app_user {
-        int app_user_id PK
-        uuid supabase_uuid "Supabaseで発行されたUUID"
-        string line_account_id
+        int app_user_id PK NOT NULL
+        uuid supabase_uuid NOT NULL "Supabaseで発行されたUUID"
+        string line_account_id NOT NULL
     }
     user_profile {
-        int user_profile_id PK
-        int app_user_id FK
-        string user_name
-        int total_otaku_score "総合オタク力"
-        int remaining_drop "所持中のドロップ数"
-        int total_otaku_layer_id FK "総合オタクレイヤー"
+        int user_profile_id PK NOT NULL
+        int app_user_id FK NOT NULL
+        string user_name NOT NULL
+        int total_otaku_score NOT NULL "総合オタク力"
+        int remaining_drop NOT NULL "所持中のドロップ数"
+        int total_otaku_layer_id FK NOT NULL "総合オタクレイヤー"
     }
     total_otaku_layer {
-        int total_otaku_layer_id PK
-        string layer_name
-        int min_score
-        int max_score
+        int total_otaku_layer_id PK NOT NULL
+        string layer_name NOT NULL
+        int min_score NOT NULL
+        int max_score NOT NULL
     }
     group_otaku_layer {
-        int group_otaku_layer_id PK
-        string layer_name
-        int min_score
-        int max_score
+        int group_otaku_layer_id PK NOT NULL
+        string layer_name NOT NULL
+        int min_score NOT NULL
+        int max_score NOT NULL
     }
     user_idol_group_score {
-        int user_idol_group_score_id PK
-        int app_user_id FK
-        int idol_group_id FK
-        int otaku_score
-        int group_otaku_layer_id FK "グループ別オタクレイヤー"
+        int user_idol_group_score_id PK NOT NULL
+        int app_user_id FK NOT NULL
+        int idol_group_id FK NOT NULL
+        int otaku_score NOT NULL
+        int group_otaku_layer_id FK NOT NULL "グループ別オタクレイヤー"
     }
     quiz_difficulty {
-        int quiz_difficulty_id PK
-        string difficulty_name
+        int quiz_difficulty_id PK NOT NULL
+        string difficulty_name NOT NULL
     }
     quiz_question {
-        int quiz_question_id PK
-        int idol_group_id FK
-        int quiz_difficulty_id FK
-        text question_text
-        string choice1
-        string choice2
-        string choice3
-        string choice4
-        int correct_choice
-        text explanation
+        int quiz_question_id PK NOT NULL
+        int idol_group_id FK NOT NULL
+        int quiz_difficulty_id FK NOT NULL
+        text question_text NOT NULL
+        string choice1 NOT NULL
+        string choice2 NOT NULL
+        string choice3 NOT NULL
+        string choice4 NOT NULL
+        int correct_choice NOT NULL
+        text explanation NOT NULL
     }
     user_quiz_answer {
-        int user_quiz_answer_id PK
-        int app_user_id FK
-        int quiz_question_id FK
-        int selected_choice
-        boolean is_correct
-        datetime answered_at
+        int user_quiz_answer_id PK NOT NULL
+        int app_user_id FK NOT NULL
+        int quiz_question_id FK NOT NULL
+        int selected_choice NOT NULL
+        boolean is_correct NOT NULL
+        datetime answered_at NOT NULL
     }
     ranking_total {
-        int ranking_total_id PK
-        int app_user_id FK
-        int display_rank "実際の総合順位"
-        int display_score "バッチ計算時点の総合スコア"
-        datetime updated_at
+        int ranking_total_id PK NOT NULL
+        int app_user_id FK NOT NULL
+        int display_rank NOT NULL "実際の総合順位"
+        int display_score NOT NULL "バッチ計算時点の総合スコア"
+        datetime updated_at NOT NULL
     }
     ranking_group {
-        int ranking_group_id PK
-        int app_user_id FK
-        int idol_group_id FK
-        int display_rank "実際のグループ順位"
-        int display_score "バッチ計算時点のグループ別スコア"
-        datetime updated_at
+        int ranking_group_id PK NOT NULL
+        int app_user_id FK NOT NULL
+        int idol_group_id FK NOT NULL
+        int display_rank NOT NULL "実際のグループ順位"
+        int display_score NOT NULL "バッチ計算時点のグループ別スコア"
+        datetime updated_at NOT NULL
     }
     event {
-        int event_id PK
-        int created_by FK "イベント作成者(app_user_id)"
-        string event_name
-        text event_description
-        string location
-        datetime event_date
-        datetime created_at
-        datetime updated_at
+        int event_id PK NOT NULL
+        int created_by FK NOT NULL "イベント作成者(app_user_id)"
+        string event_name NOT NULL
+        text event_description NOT NULL
+        string location NOT NULL
+        datetime event_date NOT NULL
+        datetime created_at NOT NULL
+        datetime updated_at NOT NULL
     }
     event_participation {
-        int event_participation_id PK
-        int event_id FK
-        int app_user_id FK
-        datetime joined_at
+        int event_participation_id PK NOT NULL
+        int event_id FK NOT NULL
+        int app_user_id FK NOT NULL
+        datetime joined_at NOT NULL
     }
     event_group_participation {
-        int event_group_participation_id PK
-        int event_id FK
-        int idol_group_id FK
-        datetime registered_at "グループ参加登録日時"
+        int event_group_participation_id PK NOT NULL
+        int event_id FK NOT NULL
+        int idol_group_id FK NOT NULL
+        datetime registered_at NOT NULL "グループ参加登録日時"
     }
-
-    %% リレーション定義
-    group_category ||--|{ idol_group : "has many"
-    idol_group }|--|| group_category : "belongs to"
-
-    app_user ||--|| user_profile : "has one profile"
-    user_profile }|--|| app_user : "belongs to"
-
-    user_profile }|--|| total_otaku_layer : "belongs to (total layer)"
-    total_otaku_layer ||--|{ user_profile : "has many"
-
-    app_user ||--|{ user_idol_group_score : "has many (per group score)"
-    user_idol_group_score }|--|| app_user : "belongs to"
-    idol_group ||--|{ user_idol_group_score : "has many"
-    user_idol_group_score }|--|| idol_group : "belongs to"
-    user_idol_group_score }|--|| group_otaku_layer : "belongs to (group layer)"
-    group_otaku_layer ||--|{ user_idol_group_score : "has many"
-
-    idol_group ||--|{ quiz_question : "has many"
-    quiz_difficulty ||--|{ quiz_question : "has many"
-    quiz_question }|--|| idol_group : "belongs to"
-    quiz_question }|--|| quiz_difficulty : "belongs to"
-
-    app_user ||--|{ user_quiz_answer : "has many"
-    user_quiz_answer }|--|| app_user : "belongs to"
-    quiz_question ||--|{ user_quiz_answer : "has many"
-    user_quiz_answer }|--|| quiz_question : "belongs to"
-
-    app_user ||--|{ ranking_total : "has one total ranking entry"
-    ranking_total }|--|| app_user : "belongs to"
-
-    app_user ||--|{ ranking_group : "has many group ranking entries"
-    ranking_group }|--|| app_user : "belongs to"
-    idol_group ||--|{ ranking_group : "has many"
-    ranking_group }|--|| idol_group : "belongs to"
-
-    app_user ||--|{ event : "creates"
-    event }|--|| app_user : "created by"
-
-    event ||--|{ event_participation : "has many"
-    event_participation }|--|| event : "belongs to"
-    app_user ||--|{ event_participation : "participates in"
-    event_participation }|--|| app_user : "belongs to"
-
-    event ||--|{ event_group_participation : "has many participating groups"
-    event_group_participation }|--|| event : "belongs to event"
-    idol_group ||--|{ event_group_participation : "has many event participations"
-    event_group_participation }|--|| idol_group : "belongs to idol group"
 ```

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -73,7 +73,7 @@ erDiagram
     ranking_total {
         int ranking_total_id PK "NOT NULL"
         int app_user_id FK "NOT NULL"
-        int display_rank "NOT NULL, 実際の総合順位"
+        int display_rank "NOT NULL, バッチ計算時点の総合順位"
         int display_score "NOT NULL, バッチ計算時点の総合スコア"
         datetime updated_at "NOT NULL"
     }
@@ -81,7 +81,7 @@ erDiagram
         int ranking_group_id PK "NOT NULL"
         int app_user_id FK "NOT NULL"
         int idol_group_id FK "NOT NULL"
-        int display_rank "NOT NULL, 実際のグループ順位"
+        int display_rank "NOT NULL, バッチ計算時点のグループ順位"
         int display_score "NOT NULL, バッチ計算時点のグループ別スコア"
         datetime updated_at "NOT NULL"
     }

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -107,52 +107,62 @@ erDiagram
         int idol_group_id FK "NOT NULL"
         datetime registered_at "NOT NULL, グループ参加登録日時"
     }
+    monthly_score_history {
+        int monthly_score_history_id PK "NOT NULL"
+        int app_user_id FK "NOT NULL"
+        datetime month "NOT NULL, 月のスナップショット (例: 2023-04-01)"
+        int score_snapshot "NOT NULL, 月初のユーザスコア"
+        datetime updated_at "NOT NULL"
+    }
 
     %% Relationship Definitions
     group_category ||--|{ idol_group : "has many"
     idol_group }|--|| group_category : "belongs to"
-
+    
     app_user ||--|| user_profile : "has one profile"
     user_profile }|--|| app_user : "belongs to"
-
+    
     user_profile }|--|| total_otaku_layer : "belongs to (total layer)"
     total_otaku_layer ||--|{ user_profile : "has many"
-
+    
     app_user ||--|{ user_idol_group_score : "has many (per group score)"
     user_idol_group_score }|--|| app_user : "belongs to"
     idol_group ||--|{ user_idol_group_score : "has many"
     user_idol_group_score }|--|| idol_group : "belongs to"
     user_idol_group_score }|--|| group_otaku_layer : "belongs to (group layer)"
     group_otaku_layer ||--|{ user_idol_group_score : "has many"
-
+    
     idol_group ||--|{ quiz_question : "has many"
     quiz_difficulty ||--|{ quiz_question : "has many"
     quiz_question }|--|| idol_group : "belongs to"
     quiz_question }|--|| quiz_difficulty : "belongs to"
-
+    
     app_user ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| app_user : "belongs to"
     quiz_question ||--|{ user_quiz_answer : "has many"
     user_quiz_answer }|--|| quiz_question : "belongs to"
-
+    
     app_user ||--|{ ranking_total : "has one total ranking entry"
     ranking_total }|--|| app_user : "belongs to"
-
+    
     app_user ||--|{ ranking_group : "has many group ranking entries"
     ranking_group }|--|| app_user : "belongs to"
     idol_group ||--|{ ranking_group : "has many"
     ranking_group }|--|| idol_group : "belongs to"
-
+    
     app_user ||--|{ event : "creates"
     event }|--|| app_user : "created by"
-
+    
     event ||--|{ event_participation : "has many"
     event_participation }|--|| event : "belongs to"
     app_user ||--|{ event_participation : "participates in"
     event_participation }|--|| app_user : "belongs to"
-
+    
     event ||--|{ event_group_participation : "has many participating groups"
     event_group_participation }|--|| event : "belongs to event"
     idol_group ||--|{ event_group_participation : "has many event participations"
     event_group_participation }|--|| idol_group : "belongs to idol group"
+    
+    app_user ||--|{ monthly_score_history : "has many monthly score entries"
+    monthly_score_history }|--|| app_user : "belongs to"
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:types": "tsc --noEmit",
     "lint": "eslint . --ext .ts,.tsx",
     "lint-fix": "eslint . --ext .ts,.tsx --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "jest": {
     "preset": "jest-expo"


### PR DESCRIPTION
## 関連Issue

close #2 
- #2 

## 関連PR

-

## 変更点

- chore(husky): pre-pushフックを`format`から`format:check`に変更
- docs(database): データベーススキーマのドキュメントとERD図を追加
- feat(scripts): CI/CD検証用の`format:check`スクリプトを追加
- style(home): index.tsxのフォーマットを修正

## 動作確認事項

- [ ] 新しい`format:check`コマンドでpre-pushフックが正常に実行されることを確認
- [ ] データベーススキーマのドキュメントがMermaid図と共に正しく表示されることを確認
- [ ] 新しい検証スクリプトで既存のフォーマットチェックが全て通過することを確認