### PR TITLE
UIコンポーネントの簡素化とテーマ管理の削除

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,7 +2,6 @@ import { Tabs } from 'expo-router'
 import { Platform } from 'react-native'
 
 import { HapticTab } from '@/components/HapticTab'
-import TabBarBackground from '@/components/ui/TabBarBackground'
 import { Colors } from '@/constants/Colors'
 import Entypo from '@expo/vector-icons/build/Entypo'
 import FontAwesome from '@expo/vector-icons/build/FontAwesome'
@@ -13,10 +12,9 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors.tint,
+        tabBarActiveTintColor: Colors.primary,
         headerShown: true,
         tabBarButton: HapticTab,
-        tabBarBackground: TabBarBackground,
         tabBarStyle: Platform.select({
           ios: {
             // Use a transparent background on iOS to show the blur effect

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,3 @@
-import {
-  DarkTheme,
-  DefaultTheme,
-  ThemeProvider,
-} from '@react-navigation/native'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useFonts } from 'expo-font'
 import { Stack } from 'expo-router'
@@ -14,7 +9,6 @@ import 'react-native-reanimated'
 
 import { GlobalProvider } from '@/context/GlobalContext'
 
-import { useColorScheme } from '@/hooks/useColorScheme'
 import { signUpNewUser } from '@/utils/auth'
 import { Toasts } from '@backpackapp-io/react-native-toast'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -32,7 +26,6 @@ const queryClient = new QueryClient({
 SplashScreen.preventAutoHideAsync()
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme()
   const [fontsLoaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   })
@@ -66,18 +59,16 @@ export default function RootLayout() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <GlobalProvider>
-          <GestureHandlerRootView style={styles.container}>
-            <Stack>
-              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-              <Stack.Screen name="+not-found" />
-            </Stack>
-            <Toasts />
-          </GestureHandlerRootView>
-        </GlobalProvider>
-        <StatusBar style="auto" />
-      </ThemeProvider>
+      <GlobalProvider>
+        <GestureHandlerRootView style={styles.container}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <Toasts />
+        </GestureHandlerRootView>
+      </GlobalProvider>
+      <StatusBar style="auto" />
     </QueryClientProvider>
   )
 }


### PR DESCRIPTION
## タイトル

UIコンポーネントの簡素化とテーマ管理の削除

## 変更点

- タブバーの背景コンポーネントを削除し、スタイリングを簡素化
  - タブのアクティブ色を`Colors.tint`から`Colors.primary`に変更
  - iOSのタブバー背景透過設定を維持
- ルートレイアウトからテーマプロバイダーを削除
  - ダーク/ライトテーマの切り替え機能を削除
  - 不要になったuseColorSchemeフックの依存関係を削除

## 動作確認事項

- タブバーの表示が正しく動作すること
- アプリ全体のテーマがデフォルトで正常に表示されること
- 既存の機能に影響がないこと
