### PR TITLE
データベーステーブル名を単数形から複数形に一括変更

### DIFF
--- a/app/(tabs)/quiz-tab/index.tsx
+++ b/app/(tabs)/quiz-tab/index.tsx
@@ -22,10 +22,10 @@ export default function GroupSelectionScreen() {
 
   const { data: groups } = useQuery({
     queryKey: ['idol_groups'],
-    queryFn: async (): Promise<Tables<'idol_group'>[]> => {
-      const { data, error } = await supabase.from('idol_group').select('*')
+    queryFn: async (): Promise<Tables<'idol_groups'>[]> => {
+      const { data, error } = await supabase.from('idol_groups').select('*')
       if (error) throw new Error(error.message)
-      return data as Tables<'idol_group'>[]
+      return data as Tables<'idol_groups'>[]
     },
   })
 

--- a/database.types.ts
+++ b/database.types.ts
@@ -34,7 +34,7 @@ export type Database = {
   }
   public: {
     Tables: {
-      app_user: {
+      app_users: {
         Row: {
           app_user_id: number
           line_account_id: string
@@ -52,7 +52,79 @@ export type Database = {
         }
         Relationships: []
       }
-      event: {
+      event_group_participations: {
+        Row: {
+          event_group_participation_id: number
+          event_id: number
+          idol_group_id: number
+          registered_at: string
+        }
+        Insert: {
+          event_group_participation_id?: number
+          event_id: number
+          idol_group_id: number
+          registered_at: string
+        }
+        Update: {
+          event_group_participation_id?: number
+          event_id?: number
+          idol_group_id?: number
+          registered_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'fk_event_group_event'
+            columns: ['event_id']
+            isOneToOne: false
+            referencedRelation: 'events'
+            referencedColumns: ['event_id']
+          },
+          {
+            foreignKeyName: 'fk_event_group_idol_group'
+            columns: ['idol_group_id']
+            isOneToOne: false
+            referencedRelation: 'idol_groups'
+            referencedColumns: ['idol_group_id']
+          },
+        ]
+      }
+      event_participations: {
+        Row: {
+          app_user_id: number
+          event_id: number
+          event_participation_id: number
+          joined_at: string
+        }
+        Insert: {
+          app_user_id: number
+          event_id: number
+          event_participation_id?: number
+          joined_at: string
+        }
+        Update: {
+          app_user_id?: number
+          event_id?: number
+          event_participation_id?: number
+          joined_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'fk_event_participation_app_user'
+            columns: ['app_user_id']
+            isOneToOne: false
+            referencedRelation: 'app_users'
+            referencedColumns: ['app_user_id']
+          },
+          {
+            foreignKeyName: 'fk_event_participation_event'
+            columns: ['event_id']
+            isOneToOne: false
+            referencedRelation: 'events'
+            referencedColumns: ['event_id']
+          },
+        ]
+      }
+      events: {
         Row: {
           created_at: string
           created_by: number
@@ -88,84 +160,12 @@ export type Database = {
             foreignKeyName: 'fk_event_created_by'
             columns: ['created_by']
             isOneToOne: false
-            referencedRelation: 'app_user'
+            referencedRelation: 'app_users'
             referencedColumns: ['app_user_id']
           },
         ]
       }
-      event_group_participation: {
-        Row: {
-          event_group_participation_id: number
-          event_id: number
-          idol_group_id: number
-          registered_at: string
-        }
-        Insert: {
-          event_group_participation_id?: number
-          event_id: number
-          idol_group_id: number
-          registered_at: string
-        }
-        Update: {
-          event_group_participation_id?: number
-          event_id?: number
-          idol_group_id?: number
-          registered_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: 'fk_event_group_event'
-            columns: ['event_id']
-            isOneToOne: false
-            referencedRelation: 'event'
-            referencedColumns: ['event_id']
-          },
-          {
-            foreignKeyName: 'fk_event_group_idol_group'
-            columns: ['idol_group_id']
-            isOneToOne: false
-            referencedRelation: 'idol_group'
-            referencedColumns: ['idol_group_id']
-          },
-        ]
-      }
-      event_participation: {
-        Row: {
-          app_user_id: number
-          event_id: number
-          event_participation_id: number
-          joined_at: string
-        }
-        Insert: {
-          app_user_id: number
-          event_id: number
-          event_participation_id?: number
-          joined_at: string
-        }
-        Update: {
-          app_user_id?: number
-          event_id?: number
-          event_participation_id?: number
-          joined_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: 'fk_event_participation_app_user'
-            columns: ['app_user_id']
-            isOneToOne: false
-            referencedRelation: 'app_user'
-            referencedColumns: ['app_user_id']
-          },
-          {
-            foreignKeyName: 'fk_event_participation_event'
-            columns: ['event_id']
-            isOneToOne: false
-            referencedRelation: 'event'
-            referencedColumns: ['event_id']
-          },
-        ]
-      }
-      group_category: {
+      group_categories: {
         Row: {
           category_name: string
           group_category_id: number
@@ -180,7 +180,7 @@ export type Database = {
         }
         Relationships: []
       }
-      group_otaku_layer: {
+      group_otaku_layers: {
         Row: {
           group_otaku_layer_id: number
           layer_name: string
@@ -201,7 +201,7 @@ export type Database = {
         }
         Relationships: []
       }
-      idol_group: {
+      idol_groups: {
         Row: {
           group_category_id: number
           idol_group_id: number
@@ -225,12 +225,12 @@ export type Database = {
             foreignKeyName: 'fk_group_category'
             columns: ['group_category_id']
             isOneToOne: false
-            referencedRelation: 'group_category'
+            referencedRelation: 'group_categories'
             referencedColumns: ['group_category_id']
           },
         ]
       }
-      monthly_score_history: {
+      monthly_score_histories: {
         Row: {
           app_user_id: number
           month: string
@@ -257,12 +257,27 @@ export type Database = {
             foreignKeyName: 'fk_monthly_score_app_user'
             columns: ['app_user_id']
             isOneToOne: false
-            referencedRelation: 'app_user'
+            referencedRelation: 'app_users'
             referencedColumns: ['app_user_id']
           },
         ]
       }
-      quiz: {
+      quiz_difficulties: {
+        Row: {
+          difficulty_name: string
+          quiz_difficulty_id: number
+        }
+        Insert: {
+          difficulty_name: string
+          quiz_difficulty_id?: number
+        }
+        Update: {
+          difficulty_name?: string
+          quiz_difficulty_id?: number
+        }
+        Relationships: []
+      }
+      quizzes: {
         Row: {
           choice1: string
           choice2: string
@@ -304,34 +319,19 @@ export type Database = {
             foreignKeyName: 'fk_quiz_question_idol_group'
             columns: ['idol_group_id']
             isOneToOne: false
-            referencedRelation: 'idol_group'
+            referencedRelation: 'idol_groups'
             referencedColumns: ['idol_group_id']
           },
           {
             foreignKeyName: 'fk_quiz_question_quiz_difficulty'
             columns: ['quiz_difficulty_id']
             isOneToOne: false
-            referencedRelation: 'quiz_difficulty'
+            referencedRelation: 'quiz_difficulties'
             referencedColumns: ['quiz_difficulty_id']
           },
         ]
       }
-      quiz_difficulty: {
-        Row: {
-          difficulty_name: string
-          quiz_difficulty_id: number
-        }
-        Insert: {
-          difficulty_name: string
-          quiz_difficulty_id?: number
-        }
-        Update: {
-          difficulty_name?: string
-          quiz_difficulty_id?: number
-        }
-        Relationships: []
-      }
-      ranking_group: {
+      ranking_groups: {
         Row: {
           app_user_id: number
           display_rank: number
@@ -361,19 +361,19 @@ export type Database = {
             foreignKeyName: 'fk_ranking_group_app_user'
             columns: ['app_user_id']
             isOneToOne: false
-            referencedRelation: 'app_user'
+            referencedRelation: 'app_users'
             referencedColumns: ['app_user_id']
           },
           {
             foreignKeyName: 'fk_ranking_group_idol_group'
             columns: ['idol_group_id']
             isOneToOne: false
-            referencedRelation: 'idol_group'
+            referencedRelation: 'idol_groups'
             referencedColumns: ['idol_group_id']
           },
         ]
       }
-      ranking_total: {
+      ranking_totals: {
         Row: {
           app_user_id: number
           display_rank: number
@@ -400,12 +400,12 @@ export type Database = {
             foreignKeyName: 'fk_ranking_total_app_user'
             columns: ['app_user_id']
             isOneToOne: false
-            referencedRelation: 'app_user'
+            referencedRelation: 'app_users'
             referencedColumns: ['app_user_id']
           },
         ]
       }
-      total_otaku_layer: {
+      total_otaku_layers: {
         Row: {
           layer_name: string
           max_score: number
@@ -426,7 +426,7 @@ export type Database = {
         }
         Relationships: []
       }
-      user_idol_group_score: {
+      user_idol_group_scores: {
         Row: {
           app_user_id: number
           group_otaku_layer_id: number
@@ -453,26 +453,26 @@ export type Database = {
             foreignKeyName: 'fk_user_idol_app_user'
             columns: ['app_user_id']
             isOneToOne: false
-            referencedRelation: 'app_user'
+            referencedRelation: 'app_users'
             referencedColumns: ['app_user_id']
           },
           {
             foreignKeyName: 'fk_user_idol_group_otaku_layer'
             columns: ['group_otaku_layer_id']
             isOneToOne: false
-            referencedRelation: 'group_otaku_layer'
+            referencedRelation: 'group_otaku_layers'
             referencedColumns: ['group_otaku_layer_id']
           },
           {
             foreignKeyName: 'fk_user_idol_idol_group'
             columns: ['idol_group_id']
             isOneToOne: false
-            referencedRelation: 'idol_group'
+            referencedRelation: 'idol_groups'
             referencedColumns: ['idol_group_id']
           },
         ]
       }
-      user_profile: {
+      user_profiles: {
         Row: {
           app_user_id: number
           remaining_drop: number
@@ -502,19 +502,19 @@ export type Database = {
             foreignKeyName: 'fk_app_user'
             columns: ['app_user_id']
             isOneToOne: false
-            referencedRelation: 'app_user'
+            referencedRelation: 'app_users'
             referencedColumns: ['app_user_id']
           },
           {
             foreignKeyName: 'fk_total_otaku_layer'
             columns: ['total_otaku_layer_id']
             isOneToOne: false
-            referencedRelation: 'total_otaku_layer'
+            referencedRelation: 'total_otaku_layers'
             referencedColumns: ['total_otaku_layer_id']
           },
         ]
       }
-      user_quiz_answer: {
+      user_quiz_answers: {
         Row: {
           answered_at: string
           app_user_id: number
@@ -544,14 +544,14 @@ export type Database = {
             foreignKeyName: 'fk_user_quiz'
             columns: ['quiz_id']
             isOneToOne: false
-            referencedRelation: 'quiz'
+            referencedRelation: 'quizzes'
             referencedColumns: ['quiz_id']
           },
           {
             foreignKeyName: 'fk_user_quiz_app_user'
             columns: ['app_user_id']
             isOneToOne: false
-            referencedRelation: 'app_user'
+            referencedRelation: 'app_users'
             referencedColumns: ['app_user_id']
           },
         ]

--- a/features/answer-quiz/components/ChoicesSection.tsx
+++ b/features/answer-quiz/components/ChoicesSection.tsx
@@ -9,7 +9,7 @@ import { ResultModal } from './result-modal'
 type DisplayStep = 'none' | 'modal' | 'explanation'
 
 type ChoicesSectionProps = {
-  quiz: Tables<'quiz'>
+  quiz: Tables<'quizzes'>
   onSolved: () => void
 }
 

--- a/features/answer-quiz/hooks/useQuizQuery.ts
+++ b/features/answer-quiz/hooks/useQuizQuery.ts
@@ -7,12 +7,12 @@ export const useQuizQuery = (quizId: string) => {
     queryKey: ['quiz', quizId],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('quiz')
+        .from('quizzes')
         .select('*')
         .eq('quiz_id', quizId)
         .single()
       if (error) throw new Error(error.message)
-      return data as Tables<'quiz'>
+      return data as Tables<'quizzes'>
     },
     enabled: !!quizId,
   })

--- a/features/answer-quiz/hooks/useQuizQuery.ts
+++ b/features/answer-quiz/hooks/useQuizQuery.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 
 export const useQuizQuery = (quizId: string) => {
   return useQuery({
-    queryKey: ['quiz', quizId],
+    queryKey: ['quizzes', quizId],
     queryFn: async () => {
       const { data, error } = await supabase
         .from('quizzes')

--- a/features/answer-quiz/hooks/useSyncUnansweredQuizIds.ts
+++ b/features/answer-quiz/hooks/useSyncUnansweredQuizIds.ts
@@ -17,7 +17,7 @@ export function useSyncUnansweredQuizIds(idolGroupId: number | null) {
   })
 
   const { data: userQuizAnswers } = useQuery({
-    queryKey: ['user_quiz_answer', currentUser?.id],
+    queryKey: ['user_quiz_answers', currentUser?.id],
     queryFn: async (): Promise<Tables<'user_quiz_answers'>[]> => {
       if (!currentUser) return []
 
@@ -32,7 +32,7 @@ export function useSyncUnansweredQuizIds(idolGroupId: number | null) {
   })
 
   const { data: groupQuizzes } = useQuery({
-    queryKey: ['quiz', idolGroupId],
+    queryKey: ['quizzes', idolGroupId],
     queryFn: async (): Promise<Tables<'quizzes'>[]> => {
       if (!idolGroupId) return []
 

--- a/features/answer-quiz/hooks/useSyncUnansweredQuizIds.ts
+++ b/features/answer-quiz/hooks/useSyncUnansweredQuizIds.ts
@@ -18,30 +18,30 @@ export function useSyncUnansweredQuizIds(idolGroupId: number | null) {
 
   const { data: userQuizAnswers } = useQuery({
     queryKey: ['user_quiz_answer', currentUser?.id],
-    queryFn: async (): Promise<Tables<'user_quiz_answer'>[]> => {
+    queryFn: async (): Promise<Tables<'user_quiz_answers'>[]> => {
       if (!currentUser) return []
 
       const { data, error } = await supabase
-        .from('user_quiz_answer')
+        .from('user_quiz_answers')
         .select('*')
         .eq('user_id', currentUser.id)
       if (error) throw new Error(error.message)
-      return data as Tables<'user_quiz_answer'>[]
+      return data as Tables<'user_quiz_answers'>[]
     },
     enabled: !!currentUser,
   })
 
   const { data: groupQuizzes } = useQuery({
     queryKey: ['quiz', idolGroupId],
-    queryFn: async (): Promise<Tables<'quiz'>[]> => {
+    queryFn: async (): Promise<Tables<'quizzes'>[]> => {
       if (!idolGroupId) return []
 
       const { data, error } = await supabase
-        .from('quiz')
+        .from('quizzes')
         .select('*')
         .eq('idol_group_id', idolGroupId)
       if (error) throw new Error(error.message)
-      return data as Tables<'quiz'>[]
+      return data as Tables<'quizzes'>[]
     },
     enabled: !!idolGroupId,
   })

--- a/supabase/migrations/202504290300_rename_tables_to_plural.sql
+++ b/supabase/migrations/202504290300_rename_tables_to_plural.sql
@@ -1,0 +1,67 @@
+BEGIN;
+
+ALTER TABLE public.app_user RENAME TO app_users;
+ALTER SEQUENCE IF EXISTS public.app_user_app_user_id_seq RENAME TO app_users_app_user_id_seq;
+ALTER TABLE public.app_users ALTER COLUMN app_user_id SET DEFAULT nextval('public.app_users_app_user_id_seq'::regclass);
+
+ALTER TABLE public.event RENAME TO events;
+ALTER SEQUENCE IF EXISTS public.event_event_id_seq RENAME TO events_event_id_seq;
+ALTER TABLE public.events ALTER COLUMN event_id SET DEFAULT nextval('public.events_event_id_seq'::regclass);
+
+ALTER TABLE public.event_group_participation RENAME TO event_group_participations;
+ALTER SEQUENCE IF EXISTS public.event_group_participation_event_group_participation_id_seq RENAME TO event_group_participations_event_group_participation_id_seq;
+ALTER TABLE public.event_group_participations ALTER COLUMN event_group_participation_id SET DEFAULT nextval('public.event_group_participations_event_group_participation_id_seq'::regclass);
+
+ALTER TABLE public.event_participation RENAME TO event_participations;
+ALTER SEQUENCE IF EXISTS public.event_participation_event_participation_id_seq RENAME TO event_participations_event_participation_id_seq;
+ALTER TABLE public.event_participations ALTER COLUMN event_participation_id SET DEFAULT nextval('public.event_participations_event_participation_id_seq'::regclass);
+
+ALTER TABLE public.group_category RENAME TO group_categories;
+ALTER SEQUENCE IF EXISTS public.group_category_group_category_id_seq RENAME TO group_categories_group_category_id_seq;
+ALTER TABLE public.group_categories ALTER COLUMN group_category_id SET DEFAULT nextval('public.group_categories_group_category_id_seq'::regclass);
+
+ALTER TABLE public.group_otaku_layer RENAME TO group_otaku_layers;
+ALTER SEQUENCE IF EXISTS public.group_otaku_layer_group_otaku_layer_id_seq RENAME TO group_otaku_layers_group_otaku_layer_id_seq;
+ALTER TABLE public.group_otaku_layers ALTER COLUMN group_otaku_layer_id SET DEFAULT nextval('public.group_otaku_layers_group_otaku_layer_id_seq'::regclass);
+
+ALTER TABLE public.idol_group RENAME TO idol_groups;
+ALTER SEQUENCE IF EXISTS public.idol_group_idol_group_id_seq RENAME TO idol_groups_idol_group_id_seq;
+ALTER TABLE public.idol_groups ALTER COLUMN idol_group_id SET DEFAULT nextval('public.idol_groups_idol_group_id_seq'::regclass);
+
+ALTER TABLE public.monthly_score_history RENAME TO monthly_score_histories;
+ALTER SEQUENCE IF EXISTS public.monthly_score_history_monthly_score_history_id_seq RENAME TO monthly_score_histories_monthly_score_history_id_seq;
+ALTER TABLE public.monthly_score_histories ALTER COLUMN monthly_score_history_id SET DEFAULT nextval('public.monthly_score_histories_monthly_score_history_id_seq'::regclass);
+
+ALTER TABLE public.quiz RENAME TO quizzes;
+ALTER SEQUENCE IF EXISTS public.quiz_quiz_id_seq RENAME TO quizzes_quiz_id_seq;
+ALTER TABLE public.quizzes ALTER COLUMN quiz_id SET DEFAULT nextval('public.quizzes_quiz_id_seq'::regclass);
+
+ALTER TABLE public.quiz_difficulty RENAME TO quiz_difficulties;
+ALTER SEQUENCE IF EXISTS public.quiz_difficulty_quiz_difficulty_id_seq RENAME TO quiz_difficulties_quiz_difficulty_id_seq;
+ALTER TABLE public.quiz_difficulties ALTER COLUMN quiz_difficulty_id SET DEFAULT nextval('public.quiz_difficulties_quiz_difficulty_id_seq'::regclass);
+
+ALTER TABLE public.ranking_group RENAME TO ranking_groups;
+ALTER SEQUENCE IF EXISTS public.ranking_group_ranking_group_id_seq RENAME TO ranking_groups_ranking_group_id_seq;
+ALTER TABLE public.ranking_groups ALTER COLUMN ranking_group_id SET DEFAULT nextval('public.ranking_groups_ranking_group_id_seq'::regclass);
+
+ALTER TABLE public.ranking_total RENAME TO ranking_totals;
+ALTER SEQUENCE IF EXISTS public.ranking_total_ranking_total_id_seq RENAME TO ranking_totals_ranking_total_id_seq;
+ALTER TABLE public.ranking_totals ALTER COLUMN ranking_total_id SET DEFAULT nextval('public.ranking_totals_ranking_total_id_seq'::regclass);
+
+ALTER TABLE public.total_otaku_layer RENAME TO total_otaku_layers;
+ALTER SEQUENCE IF EXISTS public.total_otaku_layer_total_otaku_layer_id_seq RENAME TO total_otaku_layers_total_otaku_layer_id_seq;
+ALTER TABLE public.total_otaku_layers ALTER COLUMN total_otaku_layer_id SET DEFAULT nextval('public.total_otaku_layers_total_otaku_layer_id_seq'::regclass);
+
+ALTER TABLE public.user_idol_group_score RENAME TO user_idol_group_scores;
+ALTER SEQUENCE IF EXISTS public.user_idol_group_score_user_idol_group_score_id_seq RENAME TO user_idol_group_scores_user_idol_group_score_id_seq;
+ALTER TABLE public.user_idol_group_scores ALTER COLUMN user_idol_group_score_id SET DEFAULT nextval('public.user_idol_group_scores_user_idol_group_score_id_seq'::regclass);
+
+ALTER TABLE public.user_profile RENAME TO user_profiles;
+ALTER SEQUENCE IF EXISTS public.user_profile_user_profile_id_seq RENAME TO user_profiles_user_profile_id_seq;
+ALTER TABLE public.user_profiles ALTER COLUMN user_profile_id SET DEFAULT nextval('public.user_profiles_user_profile_id_seq'::regclass);
+
+ALTER TABLE public.user_quiz_answer RENAME TO user_quiz_answers;
+ALTER SEQUENCE IF EXISTS public.user_quiz_answer_user_quiz_answer_id_seq RENAME TO user_quiz_answers_user_quiz_answer_id_seq;
+ALTER TABLE public.user_quiz_answers ALTER COLUMN user_quiz_answer_id SET DEFAULT nextval('public.user_quiz_answers_user_quiz_answer_id_seq'::regclass);
+
+COMMIT;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,97 +1,97 @@
--- total_otaku_layer
-INSERT INTO total_otaku_layer (layer_name, min_score, max_score) VALUES
-('ミーハーオタク', 0, 100),
-('見習いオタク', 101, 200),
-('初心者オタク', 201, 300),
-('沼落ちオタク', 301, 400),
-('ガチオタク', 401, 500),
-('現場主オタク', 501, 600),
-('箱推しオタク', 601, 700),
-('遠征オタク', 701, 800),
-('超熱狂オタク', 801, 900),
-('神推しオタク', 901, 1000);
+-- total_otaku_layers
+INSERT INTO total_otaku_layers (layer_name, min_score, max_score) VALUES
+  ('ミーハーオタク', 0, 100),
+  ('見習いオタク', 101, 200),
+  ('初心者オタク', 201, 300),
+  ('沼落ちオタク', 301, 400),
+  ('ガチオタク', 401, 500),
+  ('現場主オタク', 501, 600),
+  ('箱推しオタク', 601, 700),
+  ('遠征オタク', 701, 800),
+  ('超熱狂オタク', 801, 900),
+  ('神推しオタク', 901, 1000);
 
--- group_category
-INSERT INTO group_category (category_name) VALUES
-('K-Pop');
+-- group_categories
+INSERT INTO group_categories (category_name) VALUES
+  ('K-Pop');
 
--- idol_group
-INSERT INTO idol_group (group_category_id, idol_group_name, thumbnail_image) VALUES
-(1, '所属なし', NULL),
-(1, 'BTS', 'https://example.com/bts.jpg'),
-(1, 'TWICE', 'https://example.com/twice.jpg');
+-- idol_groups
+INSERT INTO idol_groups (group_category_id, idol_group_name, thumbnail_image) VALUES
+  (1, '所属なし',   NULL),
+  (1, 'BTS',       'https://example.com/bts.jpg'),
+  (1, 'TWICE',     'https://example.com/twice.jpg');
 
--- group_otaku_layer
-INSERT INTO group_otaku_layer (layer_name, min_score, max_score) VALUES
-('ミーハーオタク', 0, 20),
-('見習いオタク', 21, 40),
-('初心者オタク', 41, 60),
-('沼落ちオタク', 61, 80),
-('ガチオタク', 81, 100),
-('現場主オタク', 101, 120),
-('箱推しオタク', 121, 140),
-('遠征オタク', 141, 160),
-('超熱狂オタク', 161, 180),
-('神推しオタク', 181, 200);
+-- group_otaku_layers
+INSERT INTO group_otaku_layers (layer_name, min_score, max_score) VALUES
+  ('ミーハーオタク', 0,   20),
+  ('見習いオタク',   21,  40),
+  ('初心者オタク',   41,  60),
+  ('沼落ちオタク',   61,  80),
+  ('ガチオタク',     81,  100),
+  ('現場主オタク',   101, 120),
+  ('箱推しオタク',   121, 140),
+  ('遠征オタク',     141, 160),
+  ('超熱狂オタク',   161, 180),
+  ('神推しオタク',   181, 200);
 
--- quiz_difficulty
-INSERT INTO quiz_difficulty (difficulty_name) VALUES
-('初級'),
-('中級'),
-('上級'),
-('超上級');
+-- quiz_difficulties
+INSERT INTO quiz_difficulties (difficulty_name) VALUES
+  ('初級'),
+  ('中級'),
+  ('上級'),
+  ('超上級');
 
--- quiz
-INSERT INTO quiz
+-- quizzes
+INSERT INTO quizzes
   (idol_group_id, quiz_difficulty_id, prompt, choice1, choice2, choice3, choice4, correct_choice, explanation)
 VALUES
-(3, 1, 'TWICEのデビュー曲は次のうちどれ？',        'Like OOH-AHH', 'CHEER UP',  'TT',      'SIGNAL',   1, '2015年12月20日にデビューした。'),
-(3, 1, 'TWICEは何人グループ？',                    '9',            '7',         '8',       '10',       1, '9人組グループでデビューした。'),
-(3, 2, 'TWICEのマンネは次のうちだれ？',            'ツウィ',       'チェヨン',   'ダヒョン', 'ミナ',     1, 'ツウィは1999年6月14日生まれのグループで最年少メンバー。'),
-(3, 2, 'TWICEを生んだサバイバル番組の名称は？',      'SIXTEEN',      'SEVENTEEN', 'EIGHTEEN', 'NINETEEN', 1, 'SIXTEENは2015年に放送された女性練習生16人によるサバイバル番組。'),
-(2, 1, 'BTSのデビュー曲は次のうちどれ？',          'NO MORE DREAM','Butter',    'Dynamite','MIC Drop', 1, '2013年6月13日にデビュー。'),
-(2, 1, 'BTSは何人グループ？',                      '7',            '5',         '6',       '8',        1, '7人組グループでデビュー。'),
-(2, 1, 'BTSのマンネは次のうちだれ？',              'グク',         'テテ',       'ジミン',   'ジン',     1, 'グクは1997年9月1日生まれのグループで最年少メンバー。');
+  (3, 1, 'TWICEのデビュー曲は次のうちどれ？',        'Like OOH-AHH', 'CHEER UP',  'TT',      'SIGNAL',   1, '2015年12月20日にデビューした。'),
+  (3, 1, 'TWICEは何人グループ？',                    '9',            '7',         '8',       '10',       1, '9人組グループでデビューした。'),
+  (3, 2, 'TWICEのマンネは次のうちだれ？',            'ツウィ',       'チェヨン',   'ダヒョン', 'ミナ',     1, 'ツウィは1999年6月14日生まれのグループで最年少メンバー。'),
+  (3, 2, 'TWICEを生んだサバイバル番組の名称は？',      'SIXTEEN',      'SEVENTEEN', 'EIGHTEEN', 'NINETEEN', 1, 'SIXTEENは2015年に放送された女性練習生16人によるサバイバル番組。'),
+  (2, 1, 'BTSのデビュー曲は次のうちどれ？',          'NO MORE DREAM','Butter',    'Dynamite','MIC Drop', 1, '2013年6月13日にデビュー。'),
+  (2, 1, 'BTSは何人グループ？',                      '7',            '5',         '6',       '8',        1, '7人組グループでデビュー。'),
+  (2, 1, 'BTSのマンネは次のうちだれ？',              'グク',         'テテ',       'ジミン',   'ジン',     1, 'グクは1997年9月1日生まれのグループで最年少メンバー。');
 
--- app_user
-INSERT INTO app_user (supabase_uuid, line_account_id) VALUES
-('550e8400-e29b-41d4-a716-446655440000', 'line_id_1');
+-- app_users
+INSERT INTO app_users (supabase_uuid, line_account_id) VALUES
+  ('550e8400-e29b-41d4-a716-446655440000', 'line_id_1');
 
--- user_profile
-INSERT INTO user_profile (app_user_id, user_name, total_otaku_score, remaining_drop, total_otaku_layer_id) VALUES
-(1, 'テストユーザー', 250, 10, 3);
+-- user_profiles
+INSERT INTO user_profiles (app_user_id, user_name, total_otaku_score, remaining_drop, total_otaku_layer_id) VALUES
+  (1, 'テストユーザー', 250, 10, 3);
 
--- user_idol_group_score
-INSERT INTO user_idol_group_score (app_user_id, idol_group_id, otaku_score, group_otaku_layer_id) VALUES
-(1, 2, 150, 2),
-(1, 3, 100, 1);
+-- user_idol_group_scores
+INSERT INTO user_idol_group_scores (app_user_id, idol_group_id, otaku_score, group_otaku_layer_id) VALUES
+  (1, 2, 150, 2),
+  (1, 3, 100, 1);
 
--- user_quiz_answer
-INSERT INTO user_quiz_answer (app_user_id, quiz_id, selected_choice, is_correct, answered_at) VALUES
-(1, 1, 1, true,  NOW()),
-(1, 2, 1, true,  NOW());
+-- user_quiz_answers
+INSERT INTO user_quiz_answers (app_user_id, quiz_id, selected_choice, is_correct, answered_at) VALUES
+  (1, 1, 1, true,  NOW()),
+  (1, 2, 1, true,  NOW());
 
--- ranking_total
-INSERT INTO ranking_total (app_user_id, display_rank, display_score, updated_at) VALUES
-(1, 1, 250, NOW());
+-- ranking_totals
+INSERT INTO ranking_totals (app_user_id, display_rank, display_score, updated_at) VALUES
+  (1, 1, 250, NOW());
 
--- ranking_group
-INSERT INTO ranking_group (app_user_id, idol_group_id, display_rank, display_score, updated_at) VALUES
-(1, 2, 1, 150, NOW()),
-(1, 3, 2, 100, NOW());
+-- ranking_groups
+INSERT INTO ranking_groups (app_user_id, idol_group_id, display_rank, display_score, updated_at) VALUES
+  (1, 2, 1, 150, NOW()),
+  (1, 3, 2, 100, NOW());
 
--- event
-INSERT INTO event (created_by, event_name, event_description, location, event_date, created_at, updated_at) VALUES
-(1, 'TWICEファンイベント', 'TWICEファンの交流会', '東京', '2025-05-01 12:00:00+09', NOW(), NOW());
+-- events
+INSERT INTO events (created_by, event_name, event_description, location, event_date, created_at, updated_at) VALUES
+  (1, 'TWICEファンイベント', 'TWICEファンの交流会', '東京', '2025-05-01 12:00:00+09', NOW(), NOW());
 
--- event_participation
-INSERT INTO event_participation (event_id, app_user_id, joined_at) VALUES
-(1, 1, NOW());
+-- event_participations
+INSERT INTO event_participations (event_id, app_user_id, joined_at) VALUES
+  (1, 1, NOW());
 
--- event_group_participation
-INSERT INTO event_group_participation (event_id, idol_group_id, registered_at) VALUES
-(1, 3, NOW());
+-- event_group_participations
+INSERT INTO event_group_participations (event_id, idol_group_id, registered_at) VALUES
+  (1, 3, NOW());
 
--- monthly_score_history
-INSERT INTO monthly_score_history (app_user_id, month, score_snapshot, updated_at) VALUES
-(1, '2025-04-01', 250, NOW());
+-- monthly_score_histories
+INSERT INTO monthly_score_histories (app_user_id, month, score_snapshot, updated_at) VALUES
+  (1, '2025-04-01', 250, NOW());


### PR DESCRIPTION
## タイトル

データベーステーブル名を単数形から複数形に一括変更

## 関連Issue

-

## 関連PR

-

## 変更点

- すべてのデータベーステーブル名を単数形から複数形に変更
  - 例: `app_user` → `app_users`, `quiz` → `quizzes`
- 関連する外部キー制約を新しいテーブル名に更新
- シードデータを新しいテーブル名で更新
- TypeScriptの型定義とクエリを新しいテーブル名に合わせて更新
- マイグレーションファイルを追加して変更を適用

## 動作確認事項

- アプリケーションが正常に起動すること
- クイズ機能が正常に動作すること
- ユーザープロフィールが正常に表示されること
- ランキングデータが正常に表示されること
