### PR TITLE
クイズ結果画面を作成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run unit tests
+      - name: Run tests
         run: npm run test
 
       - name: Run type check

--- a/app/(tabs)/quiz-tab/result.tsx
+++ b/app/(tabs)/quiz-tab/result.tsx
@@ -1,21 +1,62 @@
 import { ThemedText } from '@/components/ThemedText'
 import { PrimaryButton } from '@/components/ui/button/PrimaryButton'
 import { Colors } from '@/constants/Colors'
+import { useGlobalContext } from '@/context/GlobalContext'
+import { QuizResultItem } from '@/features/answer-quiz/components/QuizResultItem'
+import { ResultSummary } from '@/features/answer-quiz/components/ResultSummary'
+import { useQuizResults } from '@/features/answer-quiz/hooks/useQuizResults'
 import { router } from 'expo-router'
-import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native'
+import {
+  ActivityIndicator,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native'
 
 export default function ResultScreen() {
+  const { answeredQuizIds } = useGlobalContext()
+  const { queryResult } = useQuizResults(answeredQuizIds)
+
+  const {
+    results: quizResults,
+    totalScore,
+    correctCount,
+  } = queryResult.data ?? { results: [], totalScore: 0, correctCount: 0 }
+
+  const isLoading = queryResult.isLoading
+
   return (
     <ScrollView style={styles.container}>
       <SafeAreaView style={styles.safeAreaView}>
         <View style={styles.headerContainer}>
-          <ThemedText type="title">結果</ThemedText>
+          <ThemedText type="title">クイズ結果</ThemedText>
         </View>
 
-        <View style={styles.resultContainer}>
-          <ThemedText style={styles.resultText}>正解です！</ThemedText>
-          <ThemedText style={styles.scoreText}>スコア: 100</ThemedText>
-        </View>
+        {isLoading ? (
+          <ActivityIndicator size="large" color={Colors.primary} />
+        ) : quizResults.length > 0 ? (
+          <>
+            <ResultSummary
+              totalScore={totalScore}
+              correctCount={correctCount}
+              totalQuestions={quizResults.length}
+            />
+
+            <View style={styles.quizListContainer}>
+              <ThemedText style={styles.sectionTitle}>
+                回答したクイズ
+              </ThemedText>
+              {quizResults.map((result, index: number) => (
+                <QuizResultItem key={index} quizResult={result} />
+              ))}
+            </View>
+          </>
+        ) : (
+          <View style={styles.emptyContainer}>
+            <ThemedText>まだクイズに回答していません</ThemedText>
+          </View>
+        )}
 
         <View style={styles.actionContainer}>
           <PrimaryButton onPress={() => router.navigate('/quiz-tab')}>
@@ -29,7 +70,8 @@ export default function ResultScreen() {
 
 const styles = StyleSheet.create({
   actionContainer: {
-    marginTop: 16,
+    marginBottom: 32,
+    marginTop: 24,
   },
   container: {
     backgroundColor: Colors.background,
@@ -37,25 +79,27 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 24,
   },
+  emptyContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
   headerContainer: {
     alignItems: 'center',
     gap: 8,
-    marginBottom: 24,
+    marginBottom: 16,
   },
-  resultContainer: {
-    alignItems: 'center',
+  quizListContainer: {
     gap: 16,
-    marginTop: 24,
-  },
-  resultText: {
-    fontSize: 20,
-    fontWeight: 'bold',
+    marginTop: 16,
   },
   safeAreaView: {
     flex: 1,
-    gap: 24,
+    gap: 16,
   },
-  scoreText: {
+  sectionTitle: {
     fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
   },
 })

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -19,4 +19,7 @@ export const Colors = {
   markCorrect: '#68c1f1',
   markIncorrect: '#f56f6f',
   error: '#d32f2f',
+  success: '#43a047',
+  lightGray: '#f5f5f5',
+  card: '#FFFFFF',
 }

--- a/features/answer-quiz/components/QuizResultItem.tsx
+++ b/features/answer-quiz/components/QuizResultItem.tsx
@@ -1,0 +1,88 @@
+import { ThemedText } from '@/components/ThemedText'
+import { Colors } from '@/constants/Colors'
+import { QuizResult } from '@/features/answer-quiz/hooks/useQuizResults'
+import { StyleSheet, View } from 'react-native'
+
+export function QuizResultItem({ quizResult }: { quizResult: QuizResult }) {
+  const { quiz, choices, userAnswer } = quizResult
+  const selectedChoice = choices.find(
+    (choice) => choice.quiz_choice_id === userAnswer.selected_choice,
+  )
+  const correctChoice = choices.find((choice) => choice.is_correct)
+
+  return (
+    <View style={styles.quizResultItem}>
+      <ThemedText style={styles.quizPrompt}>{quiz.prompt}</ThemedText>
+      <View style={styles.answerContainer}>
+        <ThemedText
+          style={[
+            styles.answerText,
+            userAnswer.is_correct ? styles.correctText : styles.incorrectText,
+          ]}
+        >
+          {userAnswer.is_correct ? '正解' : '不正解'}
+        </ThemedText>
+        <ThemedText style={styles.choiceText}>
+          あなたの回答: {selectedChoice?.choice_text}
+        </ThemedText>
+        {!userAnswer.is_correct && correctChoice && (
+          <ThemedText style={[styles.choiceText, styles.correctText]}>
+            正解: {correctChoice.choice_text}
+          </ThemedText>
+        )}
+      </View>
+      <View style={styles.explanationContainer}>
+        <ThemedText style={styles.explanationText}>
+          {quiz.explanation}
+        </ThemedText>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  answerContainer: {
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  answerText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  choiceText: {
+    fontSize: 14,
+    marginBottom: 4,
+  },
+  correctText: {
+    color: Colors.success,
+  },
+  explanationContainer: {
+    backgroundColor: Colors.lightGray,
+    borderRadius: 8,
+    marginTop: 8,
+    padding: 8,
+  },
+  explanationText: {
+    fontSize: 14,
+    fontStyle: 'italic',
+  },
+  incorrectText: {
+    color: Colors.error,
+  },
+  quizPrompt: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  quizResultItem: {
+    backgroundColor: Colors.card,
+    borderRadius: 8,
+    elevation: 1,
+    marginBottom: 12,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+  },
+})

--- a/features/answer-quiz/components/ResultSummary.tsx
+++ b/features/answer-quiz/components/ResultSummary.tsx
@@ -1,0 +1,42 @@
+import { ThemedText } from '@/components/ThemedText'
+import { Colors } from '@/constants/Colors'
+import { StyleSheet, View } from 'react-native'
+
+type ResultSummaryProps = {
+  totalScore: number
+  correctCount: number
+  totalQuestions: number
+}
+
+export function ResultSummary({
+  totalScore,
+  correctCount,
+  totalQuestions,
+}: ResultSummaryProps) {
+  return (
+    <View style={styles.resultContainer}>
+      <ThemedText style={styles.scoreText}>スコア: {totalScore}点</ThemedText>
+      <ThemedText style={styles.resultSummary}>
+        {totalQuestions}問中{correctCount}問正解
+      </ThemedText>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  resultContainer: {
+    alignItems: 'center',
+    backgroundColor: Colors.card,
+    borderRadius: 8,
+    gap: 8,
+    marginTop: 16,
+    padding: 16,
+  },
+  resultSummary: {
+    fontSize: 16,
+  },
+  scoreText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+})

--- a/features/answer-quiz/hooks/__tests__/mocks/useQuizResultsMocks.ts
+++ b/features/answer-quiz/hooks/__tests__/mocks/useQuizResultsMocks.ts
@@ -1,0 +1,100 @@
+import { Tables } from '@/database.types'
+
+const quizzesMock = [
+  {
+    quiz_id: 1,
+    prompt: 'Test Quiz 1',
+    explanation: 'Explanation 1',
+    idol_group_id: 1,
+    quiz_difficulty_id: 1,
+  },
+  {
+    quiz_id: 2,
+    prompt: 'Test Quiz 2',
+    explanation: 'Explanation 2',
+    idol_group_id: 1,
+    quiz_difficulty_id: 1,
+  },
+] as Tables<'quizzes'>[]
+
+const choicesMock = [
+  {
+    quiz_choice_id: 101,
+    quiz_id: 1,
+    choice_text: 'Correct Answer 1',
+    is_correct: true,
+  },
+  {
+    quiz_choice_id: 102,
+    quiz_id: 1,
+    choice_text: 'Wrong Answer 1',
+    is_correct: false,
+  },
+  {
+    quiz_choice_id: 201,
+    quiz_id: 2,
+    choice_text: 'Correct Answer 2',
+    is_correct: true,
+  },
+  {
+    quiz_choice_id: 202,
+    quiz_id: 2,
+    choice_text: 'Wrong Answer 2',
+    is_correct: false,
+  },
+] as Tables<'quiz_choices'>[]
+
+const userAnswersMock = [
+  {
+    user_quiz_answer_id: 1001,
+    quiz_id: 1,
+    selected_choice: 101,
+    is_correct: true,
+    answered_at: new Date().toISOString(),
+    app_user_id: 1,
+  },
+  {
+    user_quiz_answer_id: 1002,
+    quiz_id: 2,
+    selected_choice: 202,
+    is_correct: false,
+    answered_at: new Date().toISOString(),
+    app_user_id: 1,
+  },
+] as Tables<'user_quiz_answers'>[]
+
+export const setupSupabaseMocks = () => {
+  const mockSelect = jest.fn().mockReturnThis()
+  const mockIn = jest.fn().mockReturnThis()
+  const mockOrder = jest.fn().mockReturnThis()
+
+  const getMockData = (tableName: string) => {
+    if (tableName === 'user_quiz_answers') return userAnswersMock
+    if (tableName === 'quizzes') return quizzesMock
+    if (tableName === 'quiz_choices') return choicesMock
+    return []
+  }
+
+  const mockFrom = jest.fn().mockImplementation((tableName) => {
+    return {
+      select: mockSelect,
+      in: mockIn,
+      order: mockOrder,
+      then: jest.fn().mockImplementation((callback) => {
+        return Promise.resolve(
+          callback({
+            data: getMockData(tableName),
+            error: null,
+          }),
+        )
+      }),
+    }
+  })
+
+  return {
+    mockFrom,
+    mockSelect,
+    mockIn,
+    mockOrder,
+  }
+}

--- a/features/answer-quiz/hooks/__tests__/useQuizResults.empty.test.tsx
+++ b/features/answer-quiz/hooks/__tests__/useQuizResults.empty.test.tsx
@@ -1,0 +1,56 @@
+import { supabase } from '@/utils/supabase'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useQuizResults } from '../useQuizResults'
+
+describe('useQuizResults - empty case', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    queryClient.clear()
+  })
+
+  it('should return empty results when no quiz IDs are provided', async () => {
+    const mockThen = jest
+      .fn()
+      .mockImplementation((callback) =>
+        Promise.resolve().then(() => callback({ data: [], error: null })),
+      )
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      in: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      then: mockThen,
+    })
+
+    ;(supabase.from as jest.Mock) = mockFrom
+
+    const { result } = renderHook(() => useQuizResults([]), { wrapper })
+
+    expect(result.current.queryResult.isLoading).toBe(false)
+
+    await result.current.queryResult.refetch()
+
+    await waitFor(() => {
+      expect(result.current.queryResult.isSuccess).toBe(true)
+    })
+
+    expect(result.current.queryResult.data).toEqual({
+      results: [],
+      totalScore: 0,
+      correctCount: 0,
+    })
+  })
+})

--- a/features/answer-quiz/hooks/__tests__/useQuizResults.error.test.tsx
+++ b/features/answer-quiz/hooks/__tests__/useQuizResults.error.test.tsx
@@ -1,0 +1,53 @@
+import { supabase } from '@/utils/supabase'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useQuizResults } from '../useQuizResults'
+
+describe('useQuizResults - error case', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    queryClient.clear()
+  })
+
+  it('should handle Supabase error gracefully', async () => {
+    const errorMessage = 'Database connection error'
+
+    const mockThen = jest.fn().mockImplementation((callback) =>
+      Promise.resolve().then(() =>
+        callback({
+          data: null,
+          error: new Error(errorMessage),
+        }),
+      ),
+    )
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      in: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      then: mockThen,
+    })
+
+    ;(supabase.from as jest.Mock) = mockFrom
+
+    const { result } = renderHook(() => useQuizResults([1, 2]), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.queryResult.isError).toBe(true)
+    })
+
+    expect(result.current.queryResult.error).toBeDefined()
+  })
+})

--- a/features/answer-quiz/hooks/__tests__/useQuizResults.success.test.tsx
+++ b/features/answer-quiz/hooks/__tests__/useQuizResults.success.test.tsx
@@ -1,0 +1,58 @@
+import { supabase } from '@/utils/supabase'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useQuizResults } from '../useQuizResults'
+import { setupSupabaseMocks } from './mocks/useQuizResultsMocks'
+
+describe('useQuizResults - success case', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    queryClient.clear()
+  })
+
+  it('should fetch quiz results data from Supabase correctly', async () => {
+    const { mockFrom } = setupSupabaseMocks()
+    ;(supabase.from as jest.Mock) = mockFrom
+
+    const { result } = renderHook(() => useQuizResults([1, 2]), { wrapper })
+
+    await waitFor(
+      () => {
+        expect(result.current.queryResult.isSuccess).toBe(true)
+      },
+      { timeout: 3000 },
+    )
+
+    expect(mockFrom).toHaveBeenCalledWith('user_quiz_answers')
+    expect(mockFrom).toHaveBeenCalledWith('quizzes')
+    expect(mockFrom).toHaveBeenCalledWith('quiz_choices')
+
+    expect(result.current.queryResult.data).toBeDefined()
+
+    const data = result.current.queryResult.data!
+    expect(data.results).toHaveLength(2)
+
+    expect(data.totalScore).toBe(100)
+    expect(data.correctCount).toBe(1)
+
+    expect(data.results[0].quiz.quiz_id).toBe(1)
+    expect(data.results[0].userAnswer.is_correct).toBe(true)
+    expect(data.results[0].choices).toHaveLength(2)
+
+    expect(data.results[1].quiz.quiz_id).toBe(2)
+    expect(data.results[1].userAnswer.is_correct).toBe(false)
+    expect(data.results[1].choices).toHaveLength(2)
+  })
+})

--- a/features/answer-quiz/hooks/useQuizResults.ts
+++ b/features/answer-quiz/hooks/useQuizResults.ts
@@ -1,0 +1,100 @@
+import { Tables } from '@/database.types'
+import { supabase } from '@/utils/supabase'
+import { useQuery } from '@tanstack/react-query'
+
+export type QuizResult = {
+  quiz: Tables<'quizzes'>
+  choices: Tables<'quiz_choices'>[]
+  userAnswer: Tables<'user_quiz_answers'>
+}
+
+export const useQuizResults = (quizIds: number[]) => {
+  const queryResult = useQuery({
+    queryKey: ['quizResults', quizIds],
+    queryFn: () => getQuizResults(quizIds),
+    enabled: quizIds.length > 0,
+  })
+
+  return {
+    queryResult,
+  }
+}
+
+// ユーザーの回答を取得
+async function fetchUserAnswers(quizIds: number[]) {
+  const { data, error } = await supabase
+    .from('user_quiz_answers')
+    .select('*')
+    .in('quiz_id', quizIds)
+    .order('answered_at', { ascending: false })
+  if (error) throw error
+  return data
+}
+
+// クイズ情報をIDリストで取得
+async function fetchQuizzesByIds(quizIds: number[]) {
+  const { data, error } = await supabase
+    .from('quizzes')
+    .select('*')
+    .in('quiz_id', quizIds)
+  if (error) throw error
+  return data
+}
+
+// 選択肢をIDリストで取得
+async function fetchChoicesByIds(quizIds: number[]) {
+  const { data, error } = await supabase
+    .from('quiz_choices')
+    .select('*')
+    .in('quiz_id', quizIds)
+  if (error) throw error
+  return data
+}
+
+// 選択肢リストをquiz_idごとにグループ化
+function groupChoicesByQuiz(
+  choicesList: Tables<'quiz_choices'>[],
+): Record<number, Tables<'quiz_choices'>[]> {
+  return choicesList.reduce<Record<number, Tables<'quiz_choices'>[]>>(
+    (acc, choice) => {
+      const key = choice.quiz_id
+      if (!acc[key]) acc[key] = []
+      acc[key].push(choice)
+      return acc
+    },
+    {},
+  )
+}
+
+// 結果とスコアを集計
+function calculateQuizResults(
+  userAnswers: Tables<'user_quiz_answers'>[],
+  quizzes: Tables<'quizzes'>[],
+  choicesByQuiz: Record<number, Tables<'quiz_choices'>[]>,
+) {
+  let totalScore = 0
+  let correctCount = 0
+  const results: QuizResult[] = userAnswers.map((answer) => {
+    const quiz = quizzes.find((q) => q.quiz_id === answer.quiz_id)!
+    const choices = choicesByQuiz[answer.quiz_id] || []
+    if (answer.is_correct) {
+      totalScore += 100
+      correctCount += 1
+    }
+    return { quiz, choices, userAnswer: answer }
+  })
+  return { results, totalScore, correctCount }
+}
+
+// 全体の取得と集約を実行
+async function getQuizResults(quizIds: number[]) {
+  if (quizIds.length === 0) {
+    return { results: [], totalScore: 0, correctCount: 0 }
+  }
+  const userAnswers = await fetchUserAnswers(quizIds)
+  const quizIdsSet = userAnswers.map((a) => a.quiz_id)
+  const quizzes = await fetchQuizzesByIds(quizIdsSet)
+  const choicesList = await fetchChoicesByIds(quizIdsSet)
+  const choicesByQuiz = groupChoicesByQuiz(choicesList)
+  return calculateQuizResults(userAnswers, quizzes, choicesByQuiz)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17365,9 +17365,9 @@
       "license": "MIT"
     },
     "node_modules/supabase": {
-      "version": "2.22.4",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.22.4.tgz",
-      "integrity": "sha512-yYj7q8Nx9LsvMNBZb8qMeD9jEqlArOAB7yRAuIMpZqbWbuQYLTYevzPNrKOvsJl2iM0uHOhKdeG8+ywc9QnNcQ==",
+      "version": "2.22.12",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.22.12.tgz",
+      "integrity": "sha512-PWQT+uzwAXcamM/FK60CaWRjVwsX2SGW5vF7edbiTQC6vsNvTBnSIvd1yiXsIpq32uzQFu+iOrayxaTQytNiTw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",


### PR DESCRIPTION
## タイトル

クイズ結果画面の実装

## 関連Issue

-

## 関連PR

-

## 変更点

- クイズ結果画面UIの完全実装
  - クイズの正誤結果を一覧表示
  - 各クイズの回答と正解を表示
  - 合計スコアと正解数の表示
- `useQuizResults` フックの実装と単体テスト追加
  - 回答済みクイズのデータ取得処理
  - スコア計算ロジックの実装
  - エラー処理とローディング状態の管理
- UI コンポーネントの追加
  - QuizResultItem: 個別のクイズ結果表示
  - ResultSummary: スコアとクイズ統計の表示
- スタイリングの改善
  - カード型UIの導入
  - 成功/エラー色の追加
  - クイズの説明表示の改善

## 動作確認事項

- クイズに回答後、結果画面が正しく表示されることを確認
- スコア計算が正確に行われていることを確認
- 空の状態（回答したクイズがない）の表示を確認
- ローディング状態の表示を確認
- すべてのテストが正常にパスすることを確認