### PR TITLE
[feat] v2: ホームをモチベーションハブとして再設計する

### DIFF
--- a/app/v2/src/__tests__/App.test.tsx
+++ b/app/v2/src/__tests__/App.test.tsx
@@ -43,19 +43,24 @@ describe("App routes", () => {
 		vi.useRealTimers();
 	});
 
-	it("renders the home screen with welcome header and bento grid", async () => {
+	it("renders the home screen as a motivation hub", async () => {
 		await renderRoute("/");
-		expect(screen.getByText("オタ力バトルしよう！")).toBeInTheDocument();
-		expect(screen.getByText("軽いオタク")).toBeInTheDocument();
+		expect(screen.getByText("今日もオタ力を伸ばそう")).toBeInTheDocument();
+		expect(screen.getAllByText("軽いオタク").length).toBeGreaterThanOrEqual(1);
+		expect(screen.getByText("次のレベルまで")).toBeInTheDocument();
+		expect(screen.getByText("あと 350pt で インターミディエイト")).toBeInTheDocument();
 		expect(screen.getByText("問題を解く")).toBeInTheDocument();
 		expect(screen.getByText("問題を作成")).toBeInTheDocument();
 		expect(screen.getAllByText("ランキング").length).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByText("プロフィール").length).toBeGreaterThanOrEqual(1);
 	});
 
-	it("renders star rating for user level", async () => {
+	it("renders momentum cues on the home screen", async () => {
 		await renderRoute("/");
-		expect(screen.getByText("★★☆☆☆")).toBeInTheDocument();
+		expect(screen.getByText("今週 2 / 3 回プレイ")).toBeInTheDocument();
+		expect(screen.getByText("前週比 +12.5%")).toBeInTheDocument();
+		expect(screen.getByText("aespa 力 +80")).toBeInTheDocument();
+		expect(screen.getByText("350pt 差を一気に縮めよう")).toBeInTheDocument();
 	});
 
 	it("renders the bottom tab bar with four tabs", async () => {

--- a/app/v2/src/components/home/BentoCard.tsx
+++ b/app/v2/src/components/home/BentoCard.tsx
@@ -12,9 +12,10 @@ type BentoCardProps = {
 	subtitle?: string;
 	icon: LucideIcon;
 	variant?: BentoCardVariant;
+	className?: string;
 };
 
-export function BentoCard({ to, title, subtitle, icon: Icon, variant = "default" }: BentoCardProps) {
+export function BentoCard({ to, title, subtitle, icon: Icon, variant = "default", className }: BentoCardProps) {
 	const isGradient = variant === "gradient";
 
 	return (
@@ -25,6 +26,7 @@ export function BentoCard({ to, title, subtitle, icon: Icon, variant = "default"
 				isGradient
 					? "border-white/75 bg-[linear-gradient(145deg,#ff99c7_0%,#ffd7e9_100%)] text-primary-content"
 					: "border-border-soft bg-surface text-base-content hover:bg-white/90",
+				className,
 			)}
 		>
 			<div className="flex items-start justify-between gap-3">

--- a/app/v2/src/components/home/BentoGrid.tsx
+++ b/app/v2/src/components/home/BentoGrid.tsx
@@ -1,24 +1,32 @@
-import { BarChart3, PencilLine, Sparkles, UserRound } from "lucide-react";
+import { BarChart3, PencilLine, UserRound } from "lucide-react";
 import { BentoCard } from "@/components/home/BentoCard";
+import { HomeMomentumChips } from "@/components/home/HomeMomentumChips";
+import { HomeNextGoalCard } from "@/components/home/HomeNextGoalCard";
+import { HomePrimaryActionCard } from "@/components/home/HomePrimaryActionCard";
+import type { HomeMotivationViewModel } from "@/lib/ux/types";
 
-export function BentoGrid() {
+type BentoGridProps = {
+	viewModel: HomeMotivationViewModel;
+};
+
+export function BentoGrid({ viewModel }: BentoGridProps) {
 	return (
-		<div className="flex flex-col gap-3">
-			<div className="grid grid-cols-[1.15fr,0.85fr] gap-3">
-				<div className="flex-[1.2]">
-					<BentoCard to="/quiz" title="問題を解く" subtitle="今日の推し知識を増やす" icon={Sparkles} variant="gradient" />
+		<div className="flex flex-col gap-4">
+			<div className="grid gap-4 lg:grid-cols-[1.1fr,0.9fr]">
+				<div className="min-w-0">
+					<HomeNextGoalCard viewModel={viewModel} />
 				</div>
-				<div className="flex-[0.8]">
-					<BentoCard to="/quiz/create" title="問題を作成" subtitle="新しいお題を投稿" icon={PencilLine} />
+				<div className="min-w-0">
+					<HomeMomentumChips viewModel={viewModel} />
 				</div>
 			</div>
-			<div className="grid grid-cols-2 gap-3">
-				<div className="flex-1">
-					<BentoCard to="/ranking" title="ランキング" subtitle="ライバルをチェック" icon={BarChart3} />
-				</div>
-				<div className="flex-1">
-					<BentoCard to="/profile" title="プロフィール" subtitle="成長を見返す" icon={UserRound} />
-				</div>
+
+			<HomePrimaryActionCard viewModel={viewModel} />
+
+			<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+				<BentoCard to="/quiz/create" title="問題を作成" subtitle="好きな問題を追加する" icon={PencilLine} />
+				<BentoCard to="/ranking" title="ランキング" subtitle="近いライバルをチェック" icon={BarChart3} />
+				<BentoCard to="/profile" title="プロフィール" subtitle="伸びた推し力を見返す" icon={UserRound} />
 			</div>
 		</div>
 	);

--- a/app/v2/src/components/home/BentoGrid.tsx
+++ b/app/v2/src/components/home/BentoGrid.tsx
@@ -12,6 +12,8 @@ type BentoGridProps = {
 export function BentoGrid({ viewModel }: BentoGridProps) {
 	return (
 		<div className="flex flex-col gap-4">
+			<HomePrimaryActionCard viewModel={viewModel} />
+
 			<div className="grid gap-4 lg:grid-cols-[1.1fr,0.9fr]">
 				<div className="min-w-0">
 					<HomeNextGoalCard viewModel={viewModel} />
@@ -21,12 +23,10 @@ export function BentoGrid({ viewModel }: BentoGridProps) {
 				</div>
 			</div>
 
-			<HomePrimaryActionCard viewModel={viewModel} />
-
-			<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+			<div className="grid gap-3 sm:grid-cols-2">
 				<BentoCard to="/quiz/create" title="問題を作成" subtitle="好きな問題を追加する" icon={PencilLine} />
 				<BentoCard to="/ranking" title="ランキング" subtitle="近いライバルをチェック" icon={BarChart3} />
-				<BentoCard to="/profile" title="プロフィール" subtitle="伸びた推し力を見返す" icon={UserRound} />
+				<BentoCard to="/profile" title="プロフィール" subtitle="伸びた推し力を見返す" icon={UserRound} className="sm:col-span-2" />
 			</div>
 		</div>
 	);

--- a/app/v2/src/components/home/HomeMomentumChips.tsx
+++ b/app/v2/src/components/home/HomeMomentumChips.tsx
@@ -1,0 +1,46 @@
+import { Flame, Star, TrendingUp } from "lucide-react";
+import { SectionCard } from "@/components/ui/SectionCard";
+import type { HomeMotivationViewModel } from "@/lib/ux/types";
+
+type HomeMomentumChipsProps = {
+	viewModel: HomeMotivationViewModel;
+};
+
+const chipMeta = [
+	{ key: "weekly", labelKey: "weeklyPlayProgressLabel", icon: Flame },
+	{ key: "growth", labelKey: "recentGrowthLabel", icon: TrendingUp },
+	{ key: "group", labelKey: "fastestGrowingGroupLabel", icon: Star },
+] as const;
+
+export function HomeMomentumChips({ viewModel }: HomeMomentumChipsProps) {
+	const items = chipMeta
+		.map(({ key, labelKey, icon }) => ({
+			key,
+			label: viewModel[labelKey],
+			icon,
+		}))
+		.filter((item) => item.label !== null);
+
+	return (
+		<SectionCard tone="soft" className="flex h-full flex-col gap-4 px-5 py-5">
+			<div className="space-y-1">
+				<p className="text-[0.72rem] font-semibold tracking-[0.18em] text-muted-foreground">今日の勢い</p>
+				<h2 className="text-lg font-black tracking-[-0.03em] text-base-content">今日の積み上がり</h2>
+			</div>
+
+			<div className="flex flex-col gap-2.5">
+				{items.map(({ key, label, icon: Icon }) => (
+					<div
+						key={key}
+						className="flex items-center gap-3 rounded-pill border border-border-soft bg-white/78 px-4 py-3 text-sm font-semibold text-base-content shadow-soft"
+					>
+						<div className="flex size-9 items-center justify-center rounded-full bg-surface-strong text-primary">
+							<Icon className="size-4" strokeWidth={2.2} />
+						</div>
+						<span>{label}</span>
+					</div>
+				))}
+			</div>
+		</SectionCard>
+	);
+}

--- a/app/v2/src/components/home/HomeNextGoalCard.tsx
+++ b/app/v2/src/components/home/HomeNextGoalCard.tsx
@@ -1,0 +1,56 @@
+import { Crown, Target } from "lucide-react";
+import { SectionCard } from "@/components/ui/SectionCard";
+import type { HomeMotivationViewModel } from "@/lib/ux/types";
+
+type HomeNextGoalCardProps = {
+	viewModel: HomeMotivationViewModel;
+};
+
+export function HomeNextGoalCard({ viewModel }: HomeNextGoalCardProps) {
+	return (
+		<SectionCard className="flex h-full flex-col gap-4 px-5 py-5">
+			<div className="flex items-start justify-between gap-3">
+				<div className="space-y-2">
+					<p className="text-[0.72rem] font-semibold tracking-[0.18em] text-muted-foreground">次のレベルまで</p>
+					<div className="space-y-1">
+						<h2 className="text-xl font-black tracking-[-0.04em] text-base-content">{viewModel.nextGoalLabel}</h2>
+						<p className="text-sm leading-6 text-muted-foreground">{viewModel.nextGoalDescription}</p>
+					</div>
+				</div>
+				<div className="flex size-11 shrink-0 items-center justify-center rounded-[1.15rem] border border-primary/12 bg-surface-strong text-primary shadow-soft">
+					<Crown className="size-5" strokeWidth={2.2} />
+				</div>
+			</div>
+
+			{viewModel.nextTierProgressPercent === null || viewModel.nextTierName === null ? (
+				<div className="rounded-[1.1rem] border border-primary/12 bg-surface-soft px-4 py-3 text-sm font-semibold text-muted-foreground">
+					最高 tier をキープ中。次はランキング上位を狙おう。
+				</div>
+			) : (
+				<div className="space-y-3">
+					<div className="flex items-center justify-between text-xs font-semibold text-muted-foreground">
+						<span>{viewModel.currentTierName}</span>
+						<span>{viewModel.nextTierName}</span>
+					</div>
+					<div
+						role="progressbar"
+						aria-label="次のレベルまでの進捗"
+						aria-valuemin={0}
+						aria-valuemax={100}
+						aria-valuenow={viewModel.nextTierProgressPercent}
+						className="h-2.5 overflow-hidden rounded-full bg-surface-strong"
+					>
+						<div
+							className="h-full rounded-full bg-[linear-gradient(135deg,#ff8fbd,#ffbf8c)]"
+							style={{ width: `${viewModel.nextTierProgressPercent}%` }}
+						/>
+					</div>
+					<div className="inline-flex w-fit items-center gap-2 rounded-pill border border-primary/12 bg-surface-soft px-3 py-1.5 text-sm font-semibold text-base-content">
+						<Target className="size-4 text-primary" strokeWidth={2.1} />
+						{viewModel.nextTierHint}
+					</div>
+				</div>
+			)}
+		</SectionCard>
+	);
+}

--- a/app/v2/src/components/home/HomePrimaryActionCard.tsx
+++ b/app/v2/src/components/home/HomePrimaryActionCard.tsx
@@ -1,0 +1,59 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Sparkles, TimerReset } from "lucide-react";
+import { SectionCard } from "@/components/ui/SectionCard";
+import type { HomeMotivationViewModel } from "@/lib/ux/types";
+
+type HomePrimaryActionCardProps = {
+	viewModel: HomeMotivationViewModel;
+};
+
+export function HomePrimaryActionCard({ viewModel }: HomePrimaryActionCardProps) {
+	return (
+		<Link
+			to="/quiz"
+			className="group block rounded-panel focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100"
+		>
+			<SectionCard
+				tone="hero"
+				className="relative overflow-hidden border-white/80 px-5 py-5 transition duration-200 group-hover:-translate-y-0.5 group-hover:shadow-pop sm:px-6"
+			>
+				<div className="absolute inset-y-0 right-0 w-28 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.34),transparent_72%)]" />
+
+				<div className="relative flex flex-col gap-4">
+					<div className="flex items-start justify-between gap-3">
+						<div className="space-y-3">
+							<span className="inline-flex w-fit items-center rounded-full border border-white/65 bg-white/48 px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em] text-primary shadow-soft">
+								おすすめ
+							</span>
+							<div className="space-y-1">
+								<h2 className="text-[1.75rem] font-black tracking-[-0.05em] text-base-content">{viewModel.primaryCtaLabel}</h2>
+								<p className="text-sm leading-6 text-base-content/76">{viewModel.primaryCtaHint}</p>
+							</div>
+						</div>
+						<div className="flex size-12 shrink-0 items-center justify-center rounded-[1.15rem] border border-white/55 bg-white/38 text-primary shadow-soft">
+							<Sparkles className="size-5" strokeWidth={2.2} />
+						</div>
+					</div>
+
+					<div className="flex flex-wrap gap-2">
+						<div className="inline-flex items-center gap-2 rounded-pill border border-white/65 bg-white/55 px-3 py-1.5 text-sm font-semibold text-base-content shadow-soft">
+							<TimerReset className="size-4 text-primary" strokeWidth={2.1} />
+							最短3分
+						</div>
+						<div className="inline-flex items-center rounded-pill border border-white/65 bg-white/55 px-3 py-1.5 text-sm font-semibold text-base-content shadow-soft">
+							{viewModel.primaryCtaSupportLabel}
+						</div>
+					</div>
+
+					<div className="flex items-center justify-between gap-4">
+						<p className="text-sm font-semibold text-base-content/72">今日の 1 プレイでスコアを前に進めよう。</p>
+						<div className="inline-flex items-center gap-2 rounded-pill bg-white px-4 py-2 text-sm font-semibold text-primary shadow-soft transition duration-200 group-hover:translate-x-0.5">
+							今すぐ挑戦
+							<ArrowRight className="size-4" strokeWidth={2.2} />
+						</div>
+					</div>
+				</div>
+			</SectionCard>
+		</Link>
+	);
+}

--- a/app/v2/src/components/home/WelcomeHeader.tsx
+++ b/app/v2/src/components/home/WelcomeHeader.tsx
@@ -1,45 +1,52 @@
-import { Flame, Sparkles, Star } from "lucide-react";
+import { Flame, Sparkles, Target } from "lucide-react";
 import { SectionCard } from "@/components/ui/SectionCard";
+import type { HomeMotivationViewModel } from "@/lib/ux/types";
 
 type WelcomeHeaderProps = {
-	levelName: string;
-	levelStars: number;
+	viewModel: HomeMotivationViewModel;
 };
 
-export function WelcomeHeader({ levelName, levelStars }: WelcomeHeaderProps) {
-	const clampedStars = Math.min(5, Math.max(0, Math.floor(levelStars)));
-	const starLabel = `${"★".repeat(clampedStars)}${"☆".repeat(5 - clampedStars)}`;
-
+export function WelcomeHeader({ viewModel }: WelcomeHeaderProps) {
 	return (
-		<SectionCard tone="hero" className="relative overflow-hidden px-5 py-5">
-			<div className="absolute right-5 top-4 hidden size-24 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.48),transparent_70%)] blur-xl sm:block" />
-			<div className="relative flex flex-col gap-4">
+		<SectionCard tone="hero" className="relative overflow-hidden px-5 py-5 sm:px-6 sm:py-6">
+			<div className="absolute right-0 top-0 size-40 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.48),transparent_72%)] blur-2xl" />
+			<div className="absolute -left-10 bottom-0 size-32 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.38),transparent_72%)] blur-2xl" />
+
+			<div className="relative flex flex-col gap-5">
 				<div className="flex items-start justify-between gap-3">
-					<div className="space-y-2">
-						<span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/65 bg-white/50 px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em] text-primary shadow-soft">
+					<div className="space-y-3">
+						<span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/65 bg-white/45 px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em] text-primary shadow-soft">
 							<Sparkles className="size-3.5" strokeWidth={2.2} />
-							TODAY&apos;S DROP
+							{viewModel.heroEyebrow}
 						</span>
-						<div className="space-y-1">
-							<h2 className="text-[1.9rem] font-black leading-none tracking-[-0.05em] text-base-content">オタ力バトルしよう！</h2>
-							<p className="text-sm leading-6 text-base-content/70">今日の 1 プレイで、推し知識のメーターをもう少し前へ。</p>
+						<div className="space-y-2">
+							<h1 className="text-[clamp(2rem,7vw,2.85rem)] font-black leading-none tracking-[-0.06em] text-base-content">{viewModel.heroTitle}</h1>
+							<p className="max-w-[34rem] text-sm leading-6 text-base-content/76">{viewModel.heroDescription}</p>
 						</div>
 					</div>
-					<div className="flex size-12 shrink-0 items-center justify-center rounded-[1.15rem] border border-white/55 bg-white/35 text-primary shadow-soft">
+					<div className="flex size-12 shrink-0 items-center justify-center rounded-[1.15rem] border border-white/55 bg-white/38 text-primary shadow-soft">
 						<Flame className="size-5" strokeWidth={2.2} />
 					</div>
 				</div>
 
-				<div className="flex items-center justify-between gap-4 rounded-[1.35rem] border border-white/55 bg-white/52 px-4 py-3 shadow-soft">
-					<div className="space-y-1">
-						<p className="text-xs font-semibold tracking-[0.16em] text-base-content/52">CURRENT TIER</p>
-						<p className="text-base font-black tracking-[-0.03em] text-base-content">{levelName}</p>
+				<div className="grid gap-3 sm:grid-cols-[1.05fr,0.95fr]">
+					<div className="rounded-[1.35rem] border border-white/60 bg-white/52 px-4 py-4 shadow-soft">
+						<div className="mb-3 flex items-center gap-2 text-primary">
+							<Target className="size-4" strokeWidth={2.1} />
+							<p className="text-[0.68rem] font-semibold tracking-[0.18em] text-base-content/56">現在のレベル</p>
+						</div>
+						<div className="space-y-1">
+							<p className="text-xl font-black tracking-[-0.04em] text-base-content">{viewModel.currentTierName}</p>
+							<p className="text-sm font-semibold text-base-content/72">{viewModel.currentScore.toLocaleString("ja-JP")} pt</p>
+						</div>
 					</div>
-					<div className="flex items-center gap-1 text-warning">
-						<span className="sr-only">{starLabel}</span>
-						{Array.from({ length: 5 }, (_, index) => (
-							<Star key={index} className={index < clampedStars ? "size-4 fill-current" : "size-4 text-base-content/20"} strokeWidth={2.1} />
-						))}
+
+					<div className="rounded-[1.35rem] border border-white/60 bg-white/52 px-4 py-4 shadow-soft">
+						<p className="mb-3 text-[0.68rem] font-semibold tracking-[0.18em] text-base-content/56">次の狙い</p>
+						<div className="space-y-1">
+							<p className="text-base font-black tracking-[-0.03em] text-base-content">{viewModel.heroStatusLabel}</p>
+							<p className="text-sm leading-6 text-base-content/72">{viewModel.nextTierHint}</p>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/app/v2/src/lib/ux/__tests__/view-models.test.ts
+++ b/app/v2/src/lib/ux/__tests__/view-models.test.ts
@@ -16,7 +16,11 @@ describe("motivation view models", () => {
 		expect(viewModel.nextTierName).toBe("インターミディエイト");
 		expect(viewModel.pointsToNextTier).toBe(350);
 		expect(viewModel.nextTierProgressPercent).toBe(75);
+		expect(viewModel.nextGoalLabel).toBe("あと 350pt で インターミディエイト");
+		expect(viewModel.heroTitle).toBe("今日もオタ力を伸ばそう");
+		expect(viewModel.fastestGrowingGroupLabel).toBe("aespa 力 +80");
 		expect(viewModel.primaryCtaLabel).toBe("問題を解く");
+		expect(viewModel.primaryCtaSupportLabel).toBe("350pt 差を一気に縮めよう");
 	});
 
 	it("builds quiz result motivation data with a positive retry loop", () => {

--- a/app/v2/src/lib/ux/home-view-model.ts
+++ b/app/v2/src/lib/ux/home-view-model.ts
@@ -4,6 +4,36 @@ import type { HomeMotivationViewModel } from "@/lib/ux/types";
 
 export function createHomeMotivationViewModel(): HomeMotivationViewModel {
 	const progress = getTierProgress(CURRENT_USER.currentScore);
+	const topGroupName = CURRENT_USER.topGroups[0]?.groupName ?? "推し";
+	const estimatedSessionsToNextTier = progress.pointsToNextTier === null ? null : Math.max(1, Math.ceil(progress.pointsToNextTier / 180));
+	const heroDescription =
+		progress.pointsToNextTier === null
+			? "最高 tier をキープしながら、推し知識をさらに磨いていこう。"
+			: estimatedSessionsToNextTier === 1
+				? "あと 1 セッションで次のレベルが見えてくる。"
+				: `あと ${estimatedSessionsToNextTier} セッションで次のレベルが射程圏に入る。`;
+	const heroStatusLabel =
+		progress.pointsToNextTier === null || progress.nextTier === null
+			? "最高 tier を維持中"
+			: `次は ${progress.nextTier.name} まで残り ${progress.pointsToNextTier}pt`;
+	const nextGoalLabel =
+		progress.pointsToNextTier === null || progress.nextTier === null
+			? "最高 tier 到達中"
+			: `あと ${progress.pointsToNextTier}pt で ${progress.nextTier.name}`;
+	const nextGoalDescription =
+		progress.pointsToNextTier === null
+			? "このままスコアを積み上げてトップ帯をキープ。"
+			: estimatedSessionsToNextTier === 1
+				? "今日の挑戦で届くかも"
+				: `最短 ${estimatedSessionsToNextTier} セッションで届くペース`;
+	const nextTierHint =
+		progress.pointsToNextTier === null
+			? "今は最高 tier を守りながら、さらに差を広げよう。"
+			: progress.pointsToNextTier <= 120
+				? "今日の挑戦で届くかも"
+				: estimatedSessionsToNextTier === 2
+					? "あと少しで次の tier 圏内"
+					: "今のペースなら今週中に見えてくる";
 
 	return {
 		currentTierName: progress.currentTier.name,
@@ -11,13 +41,18 @@ export function createHomeMotivationViewModel(): HomeMotivationViewModel {
 		nextTierName: progress.nextTier?.name ?? null,
 		pointsToNextTier: progress.pointsToNextTier,
 		nextTierProgressPercent: progress.progressPercent,
-		weeklyPlayProgressLabel: "今週 2 / 3 回でボーナス",
+		weeklyPlayProgressLabel: "今週 2 / 3 回プレイ",
 		recentGrowthLabel: `前週比 +${CURRENT_USER.weeklyGrowthPercent}%`,
-		fastestGrowingGroupLabel: "aespa 力 +80",
+		fastestGrowingGroupLabel: `${topGroupName} 力 +80`,
 		primaryCtaLabel: "問題を解く",
 		primaryCtaHint: "最短3分でスコアアップ",
+		primaryCtaSupportLabel: progress.pointsToNextTier === null ? "最短3分でスコアを守る" : `${progress.pointsToNextTier}pt 差を一気に縮めよう`,
+		heroEyebrow: "TODAY'S DROP",
 		heroTitle: "今日もオタ力を伸ばそう",
-		heroDescription: "いちばん近い目標と、今日やる理由がすぐ見えるホームにする。",
-		nextTierHint: progress.pointsToNextTier && progress.pointsToNextTier <= 120 ? "今日の挑戦で届くかも" : "あと少しで次の tier 圏内",
+		heroDescription,
+		heroStatusLabel,
+		nextGoalLabel,
+		nextGoalDescription,
+		nextTierHint,
 	};
 }

--- a/app/v2/src/lib/ux/types.ts
+++ b/app/v2/src/lib/ux/types.ts
@@ -9,8 +9,13 @@ export type HomeMotivationViewModel = {
 	fastestGrowingGroupLabel: string | null;
 	primaryCtaLabel: string;
 	primaryCtaHint: string;
+	primaryCtaSupportLabel: string;
+	heroEyebrow: string;
 	heroTitle: string;
 	heroDescription: string;
+	heroStatusLabel: string;
+	nextGoalLabel: string;
+	nextGoalDescription: string;
 	nextTierHint: string;
 };
 

--- a/app/v2/src/routes/index.tsx
+++ b/app/v2/src/routes/index.tsx
@@ -2,17 +2,15 @@ import { createFileRoute } from "@tanstack/react-router";
 import { BentoGrid } from "@/components/home/BentoGrid";
 import { WelcomeHeader } from "@/components/home/WelcomeHeader";
 import { PageShell } from "@/components/ui/PageShell";
-
-const MOCK_USER = {
-	levelName: "軽いオタク",
-	levelStars: 2,
-};
+import { createHomeMotivationViewModel } from "@/lib/ux";
 
 function HomePage() {
+	const viewModel = createHomeMotivationViewModel();
+
 	return (
 		<PageShell className="gap-4">
-			<WelcomeHeader levelName={MOCK_USER.levelName} levelStars={MOCK_USER.levelStars} />
-			<BentoGrid />
+			<WelcomeHeader viewModel={viewModel} />
+			<BentoGrid viewModel={viewModel} />
 		</PageShell>
 	);
 }

--- a/documents/critics-review-pr-149.md
+++ b/documents/critics-review-pr-149.md
@@ -1,0 +1,56 @@
+# PR #149 チームレビュー懸念点
+
+## 概要
+
+- **PR**: v2: ホームをモチベーションハブとして再設計する
+- **URL**: https://github.com/Eiji-Kudo/k-drop/pull/149
+- **調査日**: 2026-04-06
+- **レビュー方式**: critics-lite / 修正反映済み
+
+## レビュワー構成
+
+- `ux-flow-reviewer`
+  - ホームを開いた直後に主 CTA が認識できるか、導線の強弱が崩れていないかを確認
+- `mobile-layout-reviewer`
+  - phone shell 幅でカード群が窮屈にならないか、折り返しで情報優先度が崩れないかを確認
+- `copy-consistency-reviewer`
+  - モック値でも意味が通るコピーになっているか、日本語 UI として違和感がないかを確認
+
+## 未対応の懸念点
+
+- なし
+
+## 対応済みの懸念点
+
+### 1. MEDIUM: 主 CTA が Hero と目標カードの下にあり、短い画面高では最初の視界から外れやすかった
+
+- **対象**: `app/v2/src/components/home/BentoGrid.tsx`
+- **問題点**:
+  - `問題を解く` の primary card が `次のレベルまで` と `今日の勢い` の後ろに配置されていた
+  - ホームの目的は「今日の挑戦を始める画面」なので、短いモバイル画面で主 CTA が fold 下に落ちる順序は issue の受け入れ条件と相性が悪かった
+- **対応**:
+  - `HomePrimaryActionCard` を最上段へ移動し、Hero の直後に主導線が見える順序へ変更した
+
+### 2. MEDIUM: secondary navigation を 3 カラム化すると、固定幅の phone shell ではカードが窮屈になっていた
+
+- **対象**: `app/v2/src/components/home/BentoGrid.tsx`, `app/v2/src/components/home/BentoCard.tsx`
+- **問題点**:
+  - ルートシェルが `max-w-md` のため、viewport が広い環境でも実表示幅は狭い
+  - その状態で `xl:grid-cols-3` を使うと 3 枚の secondary card が 1 行に詰まり、補助導線としての読みやすさが落ちていた
+- **対応**:
+  - secondary grid を 2 カラム基準へ戻し、`プロフィール` カードは `sm:col-span-2` でゆとりを確保した
+  - あわせて `BentoCard` に `className` を受け渡せるようにしてレイアウト調整を可能にした
+
+### 3. MEDIUM: Hero と momentum セクションに仕様書向けの文言が残り、ユーザー向けコピーとして少し硬かった
+
+- **対象**: `app/v2/src/components/home/WelcomeHeader.tsx`, `app/v2/src/components/home/HomeMomentumChips.tsx`
+- **問題点**:
+  - `現在の TIER`, `今日の狙い`, `もう進んでいることを見せる` は設計意図は伝わるが、実 UI のラベルとしてはやや説明臭かった
+- **対応**:
+  - `現在のレベル`, `次の狙い`, `今日の積み上がり` に調整し、日本語 UI として自然なトーンへ寄せた
+
+## 最終確認
+
+- 未対応の懸念点: 0件
+- 対応済みの懸念点: 3件
+- 新規発見: なし


### PR DESCRIPTION
## タイトル

v2: ホームをモチベーションハブとして再設計する

## 関連Issue

- close https://github.com/Eiji-Kudo/k-drop/issues/137

## 関連PR

- なし

## 変更点

- ホームを Hero / Primary CTA / 次目標 / momentum / secondary navigation の順に再構成し、最初の視界で主導線が分かるようにした
- `HomeMotivationViewModel` にヒーロー文言、次目標文言、CTA 補助ラベルを追加し、モック値でも意味が通るコピーに整理した
- `HomeNextGoalCard` と progress bar で次 tier までの近い目標を可視化した
- `HomeMomentumChips` で今週進捗、前週比、伸びたグループをまとめて表示し、前進感を返すようにした
- secondary card のレイアウトとテストを更新し、phone shell 幅でも窮屈にならない構成に整えた

## 動作確認事項

- [x] ホームの Hero / 次目標 / momentum / primary CTA が描画されること
  - `pnpm exec vitest run src/__tests__/App.test.tsx src/lib/ux/__tests__/view-models.test.ts` で確認済み
- [x] `HomeMotivationViewModel` の派生値が current score から一貫して算出されること
  - `pnpm exec vitest run src/lib/ux/__tests__/view-models.test.ts` で確認済み
- [ ] ブラウザでホームを開き、Hero 直下に主 CTA が見え、二次導線より強く認識できること
- [ ] ブラウザで narrow 幅でも secondary card が窮屈に見えず、`プロフィール` カードが自然に折り返されること