### PR TITLE
[feat] v2: クイズ導線と回答中UXを再設計する

### DIFF
--- a/app/v2/src/__tests__/App.test.tsx
+++ b/app/v2/src/__tests__/App.test.tsx
@@ -76,22 +76,37 @@ describe("App routes", () => {
 	it("hides the tab bar on quiz session page", async () => {
 		await renderRoute("/quiz/abc123?groupId=1");
 		expect(await screen.findByRole("heading", { name: "問題を解く" })).toBeInTheDocument();
+		expect(screen.getByRole("progressbar", { name: "セッション進捗" })).toBeInTheDocument();
 		expect(screen.queryByRole("navigation", { name: "メインナビゲーション" })).not.toBeInTheDocument();
 	});
 
 	it("navigates from group selection through the quiz flow to the result screen", async () => {
 		await renderRoute("/quiz");
 
+		expect(screen.getByRole("button", { name: "まずはグループを選ぶ" })).toBeDisabled();
 		fireEvent.click(screen.getByRole("button", { name: "BLACKPINK" }));
-		fireEvent.click(screen.getByRole("button", { name: "問題へ進む" }));
+		expect(screen.getByRole("button", { name: "BLACKPINKでスタート" })).toBeEnabled();
+		fireEvent.click(screen.getByRole("button", { name: "BLACKPINKでスタート" }));
 
 		expect(await screen.findByRole("heading", { name: "問題を解く" })).toBeInTheDocument();
+		expect(screen.getByText("進行 1 / 5")).toBeInTheDocument();
+		expect(screen.getByText("あと 4問")).toBeInTheDocument();
 
 		const answers = ["3. ナヨン", "2. Like Ooh-Ahh", "3. RM", "2. æ", "4. STARSHIPエンターテインメント"];
 
-		for (const answer of answers) {
+		for (const [index, answer] of answers.entries()) {
 			fireEvent.click(screen.getByRole("button", { name: answer }));
-			fireEvent.click(await screen.findByRole("button", { name: "次へ" }));
+			if (index === 0) {
+				const dialog = await screen.findByRole("dialog", { name: "正解" });
+				expect(dialog).toBeInTheDocument();
+				expect(within(dialog).getByText("+120 score")).toBeInTheDocument();
+				expect(within(dialog).getByText("1 COMBO")).toBeInTheDocument();
+				expect(within(dialog).getByText("あと 4問")).toBeInTheDocument();
+			} else {
+				expect(await screen.findByRole("dialog")).toBeInTheDocument();
+			}
+			fireEvent.click(screen.getByRole("button", { name: "解説を見る" }));
+			fireEvent.click(await screen.findByRole("button", { name: index === answers.length - 1 ? "結果を見る" : "次の問題へ" }));
 		}
 
 		expect(await screen.findByRole("heading", { name: "クイズ結果" })).toBeInTheDocument();

--- a/app/v2/src/components/quiz/ChoicesSection.tsx
+++ b/app/v2/src/components/quiz/ChoicesSection.tsx
@@ -1,5 +1,5 @@
 import { Sparkles } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type ChoiceVariant, QuizChoice } from "@/components/quiz/QuizChoice";
 import { type QuizAnswerFeedback, ResultModal } from "@/components/quiz/ResultModal";
 import { PrimaryCTA } from "@/components/ui/cta";
@@ -35,15 +35,17 @@ export function ChoicesSection({ choices, explanation, questionNumber, totalQues
 	const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 	const [displayPhase, setDisplayPhase] = useState<DisplayPhase>("question");
 	const [feedback, setFeedback] = useState<QuizAnswerFeedback | null>(null);
+	const selectionLockedRef = useRef(false);
 
 	const handleSelect = useCallback(
 		(index: number) => {
-			if (selectedIndex !== null) return;
+			if (selectionLockedRef.current) return;
+			selectionLockedRef.current = true;
 			setSelectedIndex(index);
 			setFeedback(onAnswer(index));
 			setDisplayPhase("selected");
 		},
-		[onAnswer, selectedIndex],
+		[onAnswer],
 	);
 
 	useEffect(() => {
@@ -53,6 +55,7 @@ export function ChoicesSection({ choices, explanation, questionNumber, totalQues
 	}, [displayPhase]);
 
 	const handleNext = useCallback(() => {
+		selectionLockedRef.current = false;
 		setSelectedIndex(null);
 		setDisplayPhase("question");
 		setFeedback(null);

--- a/app/v2/src/components/quiz/ChoicesSection.tsx
+++ b/app/v2/src/components/quiz/ChoicesSection.tsx
@@ -1,10 +1,11 @@
+import { Sparkles } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { type ChoiceVariant, QuizChoice } from "@/components/quiz/QuizChoice";
-import { ResultModal } from "@/components/quiz/ResultModal";
+import { type QuizAnswerFeedback, ResultModal } from "@/components/quiz/ResultModal";
 import { PrimaryCTA } from "@/components/ui/cta";
 import { SectionCard } from "@/components/ui/SectionCard";
 
-type DisplayPhase = "question" | "result" | "explanation";
+type DisplayPhase = "question" | "selected" | "result" | "explanation";
 
 export type Choice = {
 	choice_order: number;
@@ -15,43 +16,54 @@ export type Choice = {
 type ChoicesSectionProps = {
 	choices: ReadonlyArray<Choice>;
 	explanation: string;
+	questionNumber: number;
+	totalQuestions: number;
+	onAnswer: (selectedIndex: number) => QuizAnswerFeedback;
 	onNext: () => void;
 };
 
-function getChoiceVariant(index: number, choices: ReadonlyArray<Choice>, selectedIndex: number | null): ChoiceVariant {
-	if (selectedIndex === null) return "unanswered";
-	const choice = choices[index];
-	if (choice.is_correct) return "correct";
-	if (index === selectedIndex) return "incorrect";
-	return "unanswered";
+function getChoiceVariant(index: number, choices: ReadonlyArray<Choice>, selectedIndex: number | null, displayPhase: DisplayPhase): ChoiceVariant {
+	if (selectedIndex === null) return "idle";
+	if (displayPhase === "selected") return index === selectedIndex ? "selected" : "dimmed";
+	const selectedChoice = choices[selectedIndex];
+	if (choices[index].is_correct) return "correct";
+	if (index === selectedIndex && !selectedChoice.is_correct) return "incorrect";
+	return "dimmed";
 }
 
-export function ChoicesSection({ choices, explanation, onNext }: ChoicesSectionProps) {
+export function ChoicesSection({ choices, explanation, questionNumber, totalQuestions, onAnswer, onNext }: ChoicesSectionProps) {
 	const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 	const [displayPhase, setDisplayPhase] = useState<DisplayPhase>("question");
-
-	const isCorrect = selectedIndex !== null ? choices[selectedIndex].is_correct : null;
+	const [feedback, setFeedback] = useState<QuizAnswerFeedback | null>(null);
 
 	const handleSelect = useCallback(
 		(index: number) => {
 			if (selectedIndex !== null) return;
 			setSelectedIndex(index);
-			setDisplayPhase("result");
+			setFeedback(onAnswer(index));
+			setDisplayPhase("selected");
 		},
-		[selectedIndex],
+		[onAnswer, selectedIndex],
 	);
 
 	useEffect(() => {
-		if (displayPhase !== "result") return;
-		const timer = setTimeout(() => setDisplayPhase("explanation"), 600);
+		if (displayPhase !== "selected") return;
+		const timer = setTimeout(() => setDisplayPhase("result"), 220);
 		return () => clearTimeout(timer);
 	}, [displayPhase]);
 
 	const handleNext = useCallback(() => {
 		setSelectedIndex(null);
 		setDisplayPhase("question");
+		setFeedback(null);
 		onNext();
 	}, [onNext]);
+
+	const handleRevealExplanation = useCallback(() => {
+		setDisplayPhase("explanation");
+	}, []);
+
+	const nextLabel = questionNumber === totalQuestions ? "結果を見る" : "次の問題へ";
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -60,21 +72,25 @@ export function ChoicesSection({ choices, explanation, onNext }: ChoicesSectionP
 					key={choice.choice_order}
 					index={index}
 					label={choice.choice_text}
-					variant={getChoiceVariant(index, choices, selectedIndex)}
-					disabled={selectedIndex !== null}
+					variant={getChoiceVariant(index, choices, selectedIndex, displayPhase)}
+					disabled={displayPhase !== "question"}
 					onPress={() => handleSelect(index)}
 				/>
 			))}
 
-			{displayPhase === "result" && isCorrect !== null && <ResultModal isCorrect={isCorrect} />}
+			{displayPhase === "result" && feedback && <ResultModal feedback={feedback} onRevealExplanation={handleRevealExplanation} />}
 
 			{displayPhase === "explanation" && (
 				<>
-					<SectionCard tone="soft" className="px-4 py-4">
-						<p className="text-sm leading-6">{explanation}</p>
+					<SectionCard tone="soft" className="space-y-3 px-5 py-5">
+						<div className="flex items-center gap-2 text-[0.68rem] font-semibold tracking-[0.18em] text-primary">
+							<Sparkles className="size-3.5" strokeWidth={2.2} />
+							答えのポイント
+						</div>
+						<p className="text-sm leading-7 text-base-content">{explanation}</p>
 					</SectionCard>
 					<PrimaryCTA className="w-full" onClick={handleNext}>
-						次へ
+						{nextLabel}
 					</PrimaryCTA>
 				</>
 			)}

--- a/app/v2/src/components/quiz/QuestionPrompt.tsx
+++ b/app/v2/src/components/quiz/QuestionPrompt.tsx
@@ -2,11 +2,22 @@ import { SectionCard } from "@/components/ui/SectionCard";
 
 type QuestionPromptProps = {
 	prompt: string;
+	currentQuestion: number;
+	totalQuestions: number;
 };
 
-export function QuestionPrompt({ prompt }: QuestionPromptProps) {
+export function QuestionPrompt({ prompt, currentQuestion, totalQuestions }: QuestionPromptProps) {
 	return (
-		<SectionCard className="px-5 py-6">
+		<SectionCard className="space-y-4 px-5 py-5">
+			<div className="flex items-start justify-between gap-3">
+				<div className="space-y-1">
+					<p className="text-[0.68rem] font-semibold tracking-[0.2em] text-primary">QUESTION {currentQuestion}</p>
+					<p className="text-sm leading-6 text-muted-foreground">一番しっくりくる答えをひとつ選ぼう。</p>
+				</div>
+				<span className="inline-flex items-center rounded-pill border border-border-soft bg-white/80 px-3 py-1 text-xs font-semibold text-base-content shadow-soft">
+					{currentQuestion} / {totalQuestions}
+				</span>
+			</div>
 			<p className="text-xl font-black leading-8 tracking-[-0.03em] text-base-content">{prompt}</p>
 		</SectionCard>
 	);

--- a/app/v2/src/components/quiz/QuizChoice.tsx
+++ b/app/v2/src/components/quiz/QuizChoice.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/cn";
 
-export type ChoiceVariant = "unanswered" | "correct" | "incorrect";
+export type ChoiceVariant = "idle" | "selected" | "correct" | "incorrect" | "dimmed";
 
 type QuizChoiceProps = {
 	index: number;
@@ -11,26 +11,45 @@ type QuizChoiceProps = {
 };
 
 const variantStyles: Record<ChoiceVariant, string> = {
-	unanswered: "border-border-soft bg-surface text-base-content hover:bg-white",
-	correct: "border-success/20 bg-[#effcf3] text-[#0b6b2f]",
-	incorrect: "border-error/15 bg-[#fff0f1] text-[#b5273a]",
+	idle: "border-white/80 bg-surface-soft text-base-content hover:-translate-y-0.5 hover:bg-white hover:shadow-pop",
+	selected: "border-primary/30 bg-surface-strong text-base-content shadow-pop",
+	correct: "border-success/18 bg-[linear-gradient(180deg,#f7fff9_0%,#ebfff1_100%)] text-[#0c6f32] shadow-pop",
+	incorrect: "border-error/15 bg-[linear-gradient(180deg,#fff7f8_0%,#ffecef_100%)] text-[#b5273a] shadow-soft",
+	dimmed: "border-border-soft bg-white/70 text-muted-foreground shadow-soft",
+};
+
+const badgeStyles: Record<ChoiceVariant, string> = {
+	idle: "border-border-soft bg-white/85 text-base-content",
+	selected: "border-primary/20 bg-primary/12 text-primary",
+	correct: "border-success/18 bg-success/10 text-[#0c6f32]",
+	incorrect: "border-error/15 bg-error/10 text-[#b5273a]",
+	dimmed: "border-border-soft bg-white/75 text-muted-foreground",
 };
 
 export function QuizChoice({ index, label, variant, disabled, onPress }: QuizChoiceProps) {
-	const disabledStyle = disabled && variant === "unanswered" ? "cursor-not-allowed opacity-50" : "";
+	const disabledStyle = disabled && variant === "idle" ? "cursor-not-allowed opacity-50" : "";
 
 	return (
 		<button
 			type="button"
 			className={cn(
-				"w-full rounded-panel border px-4 py-4 text-left text-base font-semibold shadow-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100",
+				"w-full rounded-panel border px-4 py-4 text-left text-base font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100",
 				variantStyles[variant],
 				disabledStyle,
 			)}
 			disabled={disabled}
 			onClick={onPress}
 		>
-			{`${index + 1}. ${label}`}
+			<div className="flex items-start gap-3">
+				<span
+					className={cn("flex size-9 shrink-0 items-center justify-center rounded-full border text-sm font-black shadow-soft", badgeStyles[variant])}
+				>
+					{`${index + 1}.`}
+				</span>
+				<div className="pt-1">
+					<p className="text-base font-black leading-6 tracking-[-0.02em]">{label}</p>
+				</div>
+			</div>
 		</button>
 	);
 }

--- a/app/v2/src/components/quiz/QuizHeader.tsx
+++ b/app/v2/src/components/quiz/QuizHeader.tsx
@@ -1,5 +1,71 @@
-import { PageHeader } from "@/components/ui/PageHeader";
+import { SectionCard } from "@/components/ui/SectionCard";
 
-export function QuizHeader() {
-	return <PageHeader eyebrow="QUIZ BATTLE" title="問題を解く" description="ひらめいたら、そのままテンポよく答えていこう。" />;
+type QuizHeaderProps = {
+	groupName: string;
+	currentQuestion: number;
+	totalQuestions: number;
+	remainingQuestions: number;
+	correctCount: number;
+	progressPercent: number;
+};
+
+export function QuizHeader({ groupName, currentQuestion, totalQuestions, remainingQuestions, correctCount, progressPercent }: QuizHeaderProps) {
+	return (
+		<SectionCard tone="hero" className="space-y-4 px-5 py-5">
+			<div className="flex items-start justify-between gap-3">
+				<div className="space-y-2">
+					<span className="inline-flex items-center rounded-pill border border-white/80 bg-white/75 px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em] text-primary shadow-soft">
+						{groupName}
+					</span>
+					<div className="space-y-1">
+						<h1 className="text-[1.95rem] font-black leading-none tracking-[-0.05em] text-base-content">問題を解く</h1>
+						<p className="text-sm leading-6 text-muted-foreground">今いる位置を見失わず、そのままテンポよく進めよう。</p>
+					</div>
+				</div>
+				<div className="rounded-[1.35rem] border border-white/80 bg-white/75 px-4 py-3 text-right shadow-soft">
+					<p className="text-[0.68rem] font-semibold tracking-[0.18em] text-primary">QUESTION</p>
+					<p className="mt-1 text-2xl font-black tracking-[-0.04em] text-base-content">{currentQuestion}</p>
+					<p className="text-xs text-muted-foreground">/ {totalQuestions}</p>
+				</div>
+			</div>
+
+			<div className="space-y-2">
+				<div className="flex items-center justify-between text-xs font-semibold text-muted-foreground">
+					<span>
+						進行 {currentQuestion} / {totalQuestions}
+					</span>
+					<span>{remainingQuestions === 0 ? "ラスト" : `あと ${remainingQuestions}問`}</span>
+				</div>
+				<div
+					className="h-2 overflow-hidden rounded-pill bg-white/70"
+					role="progressbar"
+					aria-label="セッション進捗"
+					aria-valuemin={0}
+					aria-valuemax={100}
+					aria-valuenow={progressPercent}
+				>
+					<div className="h-full rounded-pill bg-[linear-gradient(135deg,#ff91c0,#ffbfd8)]" style={{ width: `${progressPercent}%` }} />
+				</div>
+			</div>
+
+			<div className="grid grid-cols-3 gap-2">
+				<div className="rounded-[1.25rem] border border-white/80 bg-white/72 px-3 py-3 shadow-soft">
+					<p className="text-[0.68rem] font-semibold tracking-[0.18em] text-primary">進行</p>
+					<p className="mt-1 text-base font-black tracking-[-0.03em] text-base-content">
+						{currentQuestion} / {totalQuestions}
+					</p>
+				</div>
+				<div className="rounded-[1.25rem] border border-white/80 bg-white/72 px-3 py-3 shadow-soft">
+					<p className="text-[0.68rem] font-semibold tracking-[0.18em] text-primary">残り</p>
+					<p className="mt-1 text-base font-black tracking-[-0.03em] text-base-content">
+						{remainingQuestions === 0 ? "ラスト" : `${remainingQuestions}問`}
+					</p>
+				</div>
+				<div className="rounded-[1.25rem] border border-white/80 bg-white/72 px-3 py-3 shadow-soft">
+					<p className="text-[0.68rem] font-semibold tracking-[0.18em] text-primary">正解</p>
+					<p className="mt-1 text-base font-black tracking-[-0.03em] text-base-content">{correctCount}問</p>
+				</div>
+			</div>
+		</SectionCard>
+	);
 }

--- a/app/v2/src/components/quiz/QuizQuestionScreen.tsx
+++ b/app/v2/src/components/quiz/QuizQuestionScreen.tsx
@@ -3,30 +3,90 @@ import { ChoicesSection } from "@/components/quiz/ChoicesSection";
 import { MOCK_QUESTIONS } from "@/components/quiz/mock-questions";
 import { QuestionPrompt } from "@/components/quiz/QuestionPrompt";
 import { QuizHeader } from "@/components/quiz/QuizHeader";
+import { type QuizAnswerFeedback } from "@/components/quiz/ResultModal";
 import { PageShell } from "@/components/ui/PageShell";
 
 type QuizQuestionScreenProps = {
+	groupName: string;
 	onComplete: () => void;
 };
 
-export function QuizQuestionScreen({ onComplete }: QuizQuestionScreenProps) {
+export function QuizQuestionScreen({ groupName, onComplete }: QuizQuestionScreenProps) {
 	const [currentIndex, setCurrentIndex] = useState(0);
+	const [correctCount, setCorrectCount] = useState(0);
+	const [comboCount, setComboCount] = useState(0);
 
 	const question = MOCK_QUESTIONS[currentIndex];
+	const totalQuestions = MOCK_QUESTIONS.length;
+	const currentQuestion = currentIndex + 1;
+	const remainingQuestions = totalQuestions - currentQuestion;
+	const progressPercent = Math.round((currentQuestion / totalQuestions) * 100);
+
+	const handleAnswer = useCallback(
+		(selectedIndex: number): QuizAnswerFeedback => {
+			const isCorrect = question.choices[selectedIndex]?.is_correct ?? false;
+			const nextCombo = isCorrect ? comboCount + 1 : 0;
+			const gainedScore = isCorrect ? 120 + comboCount * 30 : 30;
+
+			if (isCorrect) {
+				setCorrectCount((prev) => prev + 1);
+			}
+			setComboCount(nextCombo);
+
+			return isCorrect
+				? {
+						isCorrect: true,
+						statusLabel: nextCombo >= 2 ? "HOT STREAK" : "NICE HIT",
+						headline: "正解",
+						message:
+							nextCombo >= 2
+								? `+${gainedScore} score。${nextCombo}コンボで、そのまま流れに乗れている。`
+								: `+${gainedScore} score。いい入りで、次の1問にもつなげやすい。`,
+						gainedScore,
+						comboCount: nextCombo,
+						remainingQuestions,
+					}
+				: {
+						isCorrect: false,
+						statusLabel: "KEEP GOING",
+						headline: "次で取り返せる",
+						message: `+${gainedScore} score。解説で押さえたら、次の1問からまた流れを作れる。`,
+						gainedScore,
+						comboCount: nextCombo,
+						remainingQuestions,
+					};
+		},
+		[comboCount, question.choices, remainingQuestions],
+	);
 
 	const handleNext = useCallback(() => {
-		if (currentIndex + 1 >= MOCK_QUESTIONS.length) {
+		if (currentQuestion >= totalQuestions) {
 			onComplete();
 			return;
 		}
 		setCurrentIndex((prev) => prev + 1);
-	}, [currentIndex, onComplete]);
+	}, [currentQuestion, onComplete, totalQuestions]);
 
 	return (
 		<PageShell className="gap-6">
-			<QuizHeader />
-			<QuestionPrompt prompt={question.prompt} />
-			<ChoicesSection key={currentIndex} choices={question.choices} explanation={question.explanation} onNext={handleNext} />
+			<QuizHeader
+				groupName={groupName}
+				currentQuestion={currentQuestion}
+				totalQuestions={totalQuestions}
+				remainingQuestions={remainingQuestions}
+				correctCount={correctCount}
+				progressPercent={progressPercent}
+			/>
+			<QuestionPrompt prompt={question.prompt} currentQuestion={currentQuestion} totalQuestions={totalQuestions} />
+			<ChoicesSection
+				key={currentIndex}
+				choices={question.choices}
+				explanation={question.explanation}
+				questionNumber={currentQuestion}
+				totalQuestions={totalQuestions}
+				onAnswer={handleAnswer}
+				onNext={handleNext}
+			/>
 		</PageShell>
 	);
 }

--- a/app/v2/src/components/quiz/ResultModal.tsx
+++ b/app/v2/src/components/quiz/ResultModal.tsx
@@ -1,19 +1,96 @@
-type ResultModalProps = {
+import { ArrowRight, Flame, Sparkles, Target } from "lucide-react";
+import { PrimaryCTA } from "@/components/ui/cta";
+import { cn } from "@/lib/cn";
+
+export type QuizAnswerFeedback = {
 	isCorrect: boolean;
+	statusLabel: string;
+	headline: string;
+	message: string;
+	gainedScore: number;
+	comboCount: number;
+	remainingQuestions: number;
 };
 
-export function ResultModal({ isCorrect }: ResultModalProps) {
-	const symbol = isCorrect ? "◎" : "×";
-	const text = isCorrect ? "正解!" : "不正解";
-	const toneClassName = isCorrect ? "border-info/20 bg-[#eff8ff] text-info-content" : "border-error/20 bg-[#fff1f3] text-[#ab2438]";
+type ResultModalProps = {
+	feedback: QuizAnswerFeedback;
+	onRevealExplanation: () => void;
+};
+
+export function ResultModal({ feedback, onRevealExplanation }: ResultModalProps) {
+	const toneClassName = feedback.isCorrect
+		? {
+				panel: "border-success/15 bg-[linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(241,255,247,0.94)_100%)]",
+				badge: "border-success/15 bg-success/10 text-[#0c6f32]",
+				icon: "border-success/15 bg-success/10 text-[#0c6f32]",
+			}
+		: {
+				panel: "border-error/12 bg-[linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(255,243,246,0.94)_100%)]",
+				badge: "border-error/12 bg-error/10 text-[#b5273a]",
+				icon: "border-error/12 bg-error/10 text-[#b5273a]",
+			};
+	const comboLabel = feedback.comboCount > 0 ? `${feedback.comboCount} COMBO` : "NEXT 1";
+	const remainingLabel = feedback.remainingQuestions === 0 ? "LAST" : `あと ${feedback.remainingQuestions}問`;
 
 	return (
-		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20" role="dialog" aria-modal="true" aria-label={text}>
-			<div
-				className={`flex aspect-square w-[70vw] max-w-[300px] flex-col items-center justify-start gap-4 rounded-panel border bg-white/90 pt-5 shadow-pop backdrop-blur-sm ${toneClassName}`}
-			>
-				<p className="text-2xl font-extrabold">{text}</p>
-				<span className="text-[min(calc(70vw*0.55),165px)] font-black leading-none">{symbol}</span>
+		<div
+			className="fixed inset-0 z-50 flex items-end justify-center bg-[#4f2443]/18 p-4 sm:items-center"
+			role="dialog"
+			aria-modal="true"
+			aria-label={feedback.headline}
+		>
+			<div className={cn("w-full max-w-[24rem] rounded-[2rem] border p-5 shadow-pop backdrop-blur-md", toneClassName.panel)}>
+				<div className="space-y-5">
+					<div className="flex items-start justify-between gap-3">
+						<div className="space-y-2">
+							<span
+								className={cn(
+									"inline-flex items-center gap-2 rounded-pill border px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em]",
+									toneClassName.badge,
+								)}
+							>
+								<Sparkles className="size-3.5" strokeWidth={2.2} />
+								{feedback.statusLabel}
+							</span>
+							<div className="space-y-1">
+								<p className="text-[1.85rem] font-black leading-none tracking-[-0.05em] text-base-content">{feedback.headline}</p>
+								<p className="text-sm leading-6 text-muted-foreground">{feedback.message}</p>
+							</div>
+						</div>
+						<div className={cn("flex size-12 shrink-0 items-center justify-center rounded-full border shadow-soft", toneClassName.icon)}>
+							{feedback.isCorrect ? <Sparkles className="size-5" strokeWidth={2.2} /> : <Target className="size-5" strokeWidth={2.2} />}
+						</div>
+					</div>
+
+					<div className="grid grid-cols-3 gap-2">
+						<div className="rounded-[1.25rem] border border-white/80 bg-white/78 px-3 py-3 shadow-soft">
+							<div className="flex items-center gap-2 text-[0.68rem] font-semibold tracking-[0.18em] text-primary">
+								<Sparkles className="size-3.5" strokeWidth={2.2} />
+								SCORE
+							</div>
+							<p className="mt-2 text-base font-black tracking-[-0.03em] text-base-content">+{feedback.gainedScore} score</p>
+						</div>
+						<div className="rounded-[1.25rem] border border-white/80 bg-white/78 px-3 py-3 shadow-soft">
+							<div className="flex items-center gap-2 text-[0.68rem] font-semibold tracking-[0.18em] text-primary">
+								<Flame className="size-3.5" strokeWidth={2.2} />
+								COMBO
+							</div>
+							<p className="mt-2 text-base font-black tracking-[-0.03em] text-base-content">{comboLabel}</p>
+						</div>
+						<div className="rounded-[1.25rem] border border-white/80 bg-white/78 px-3 py-3 shadow-soft">
+							<div className="flex items-center gap-2 text-[0.68rem] font-semibold tracking-[0.18em] text-primary">
+								<Target className="size-3.5" strokeWidth={2.2} />
+								LEFT
+							</div>
+							<p className="mt-2 text-base font-black tracking-[-0.03em] text-base-content">{remainingLabel}</p>
+						</div>
+					</div>
+
+					<PrimaryCTA className="w-full" onClick={onRevealExplanation}>
+						解説を見る
+						<ArrowRight className="ml-2 size-4" strokeWidth={2.2} />
+					</PrimaryCTA>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/v2/src/mocks/quiz-groups.ts
+++ b/app/v2/src/mocks/quiz-groups.ts
@@ -1,0 +1,79 @@
+export type QuizGroup = {
+	idolGroupId: string;
+	groupName: string;
+	tagline: string;
+	questionCount: number;
+	vibeLabel: string;
+	rewardHint: string;
+};
+
+export const QUIZ_GROUPS: ReadonlyArray<QuizGroup> = [
+	{
+		idolGroupId: "1",
+		groupName: "BLACKPINK",
+		tagline: "王道ヒットをテンポよく確認したい日に。",
+		questionCount: 5,
+		vibeLabel: "定番セット",
+		rewardHint: "+120 score からスタート",
+	},
+	{
+		idolGroupId: "2",
+		groupName: "BTS",
+		tagline: "知識量を試したいときの濃いめラウンド。",
+		questionCount: 5,
+		vibeLabel: "熱量高め",
+		rewardHint: "コンボで一気に伸ばせる",
+	},
+	{
+		idolGroupId: "3",
+		groupName: "TWICE",
+		tagline: "曲名とメンバーを軽快に取りにいく。",
+		questionCount: 5,
+		vibeLabel: "ウォームアップ",
+		rewardHint: "3分で気持ちよく進める",
+	},
+	{
+		idolGroupId: "4",
+		groupName: "aespa",
+		tagline: "世界観系の問題で流れを作りたいときに。",
+		questionCount: 5,
+		vibeLabel: "世界観重視",
+		rewardHint: "推し力を積み上げやすい",
+	},
+	{
+		idolGroupId: "5",
+		groupName: "Stray Kids",
+		tagline: "勢い重視でテンションを上げたい日に。",
+		questionCount: 5,
+		vibeLabel: "勢い全開",
+		rewardHint: "連続正解で加速",
+	},
+	{
+		idolGroupId: "6",
+		groupName: "IVE",
+		tagline: "知っている曲から気持ちよく入りやすい。",
+		questionCount: 5,
+		vibeLabel: "入りやすい",
+		rewardHint: "初手にちょうどいい",
+	},
+	{
+		idolGroupId: "7",
+		groupName: "LE SSERAFIM",
+		tagline: "最近の推し活をそのまま試したい人向け。",
+		questionCount: 5,
+		vibeLabel: "今っぽい",
+		rewardHint: "集中が切れにくい短尺",
+	},
+	{
+		idolGroupId: "8",
+		groupName: "NewJeans",
+		tagline: "耳なじみのある問題でリズムよく進める。",
+		questionCount: 5,
+		vibeLabel: "軽快",
+		rewardHint: "次の挑戦につなげやすい",
+	},
+];
+
+export function findQuizGroup(groupId: string) {
+	return QUIZ_GROUPS.find((group) => group.idolGroupId === groupId);
+}

--- a/app/v2/src/routes/quiz/$sessionId.tsx
+++ b/app/v2/src/routes/quiz/$sessionId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { QuizQuestionScreen } from "@/components/quiz/QuizQuestionScreen";
+import { findQuizGroup } from "@/mocks/quiz-groups";
 
 type QuizSessionSearch = {
 	groupId: string;
@@ -7,8 +8,10 @@ type QuizSessionSearch = {
 
 function QuizSessionPage() {
 	const navigate = useNavigate();
+	const { groupId } = Route.useSearch();
+	const groupName = findQuizGroup(groupId)?.groupName ?? "K-POP";
 
-	return <QuizQuestionScreen onComplete={() => void navigate({ to: "/quiz/result" })} />;
+	return <QuizQuestionScreen groupName={groupName} onComplete={() => void navigate({ to: "/quiz/result" })} />;
 }
 
 export const Route = createFileRoute("/quiz/$sessionId")({

--- a/app/v2/src/routes/quiz/index.tsx
+++ b/app/v2/src/routes/quiz/index.tsx
@@ -1,55 +1,66 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { ArrowRight, CheckCircle2 } from "lucide-react";
+import { ArrowRight, CheckCircle2, PlayCircle, Sparkles, Star } from "lucide-react";
 import { useState } from "react";
 import { PrimaryCTA } from "@/components/ui/cta";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { PageShell } from "@/components/ui/PageShell";
+import { SectionCard } from "@/components/ui/SectionCard";
 import { cn } from "@/lib/cn";
-
-type IdolGroup = {
-	idolGroupId: string;
-	groupName: string;
-	thumbnailUrl: string;
-};
-
-const MOCK_IDOL_GROUPS: ReadonlyArray<IdolGroup> = [
-	{ idolGroupId: "1", groupName: "BLACKPINK", thumbnailUrl: "" },
-	{ idolGroupId: "2", groupName: "BTS", thumbnailUrl: "" },
-	{ idolGroupId: "3", groupName: "TWICE", thumbnailUrl: "" },
-	{ idolGroupId: "4", groupName: "aespa", thumbnailUrl: "" },
-	{ idolGroupId: "5", groupName: "Stray Kids", thumbnailUrl: "" },
-	{ idolGroupId: "6", groupName: "IVE", thumbnailUrl: "" },
-	{ idolGroupId: "7", groupName: "LE SSERAFIM", thumbnailUrl: "" },
-	{ idolGroupId: "8", groupName: "NewJeans", thumbnailUrl: "" },
-];
+import { QUIZ_GROUPS, type QuizGroup } from "@/mocks/quiz-groups";
 
 function GroupSelectionHeader() {
 	return <PageHeader eyebrow="QUIZ START" title="ジャンルを選択" description="今の気分に合うグループを選んで、すぐにクイズへ入れます。" />;
 }
 
-function GroupButton({ group, isSelected, onPress }: { group: IdolGroup; isSelected: boolean; onPress: (groupId: string) => void }) {
+function GroupButton({ group, isSelected, onPress }: { group: QuizGroup; isSelected: boolean; onPress: (groupId: string) => void }) {
 	return (
 		<button
 			type="button"
 			onClick={() => onPress(group.idolGroupId)}
 			aria-label={group.groupName}
 			className={cn(
-				"flex w-full items-center justify-between rounded-panel border px-4 py-4 text-left shadow-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100",
+				"flex w-full flex-col gap-4 rounded-panel border px-4 py-4 text-left shadow-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100",
 				isSelected
-					? "border-primary/25 bg-surface-strong text-base-content shadow-pop"
-					: "border-border-soft bg-surface text-base-content hover:bg-white",
+					? "border-primary/30 bg-surface-strong text-base-content shadow-pop"
+					: "border-white/80 bg-surface-soft text-base-content hover:-translate-y-0.5 hover:bg-white hover:shadow-pop",
 			)}
 			aria-pressed={isSelected}
 		>
-			<div className="space-y-1">
-				<p className="text-base font-black tracking-[-0.03em]">{group.groupName}</p>
-				<p className="text-xs text-muted-foreground">このグループの問題セットに挑戦する</p>
+			<div className="flex items-start justify-between gap-3">
+				<div className="space-y-2">
+					<div className="flex flex-wrap items-center gap-2">
+						<span className="inline-flex items-center rounded-pill border border-white/80 bg-white/75 px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em] text-primary shadow-soft">
+							{group.vibeLabel}
+						</span>
+						{isSelected && (
+							<span className="inline-flex items-center gap-1 rounded-pill border border-primary/15 bg-primary/10 px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em] text-primary">
+								<CheckCircle2 className="size-3.5" strokeWidth={2.2} />
+								選択中
+							</span>
+						)}
+					</div>
+					<div className="space-y-1">
+						<p className="text-lg font-black tracking-[-0.03em]">{group.groupName}</p>
+						<p className="text-sm leading-6 text-muted-foreground">{group.tagline}</p>
+					</div>
+				</div>
+				<div
+					className={cn(
+						"mt-1 flex size-11 shrink-0 items-center justify-center rounded-full border shadow-soft",
+						isSelected ? "border-primary/25 bg-primary/12 text-primary" : "border-white/80 bg-white/80 text-muted-foreground",
+					)}
+				>
+					{isSelected ? <CheckCircle2 className="size-5" strokeWidth={2.2} /> : <ArrowRight className="size-4.5" strokeWidth={2.2} />}
+				</div>
 			</div>
-			{isSelected ? (
-				<CheckCircle2 className="size-5 shrink-0 text-primary" strokeWidth={2.2} />
-			) : (
-				<ArrowRight className="size-4 shrink-0 text-muted-foreground" />
-			)}
+			<div className="flex flex-wrap gap-2">
+				<span className="inline-flex items-center rounded-pill border border-border-soft bg-white/80 px-3 py-1 text-xs font-semibold text-base-content shadow-soft">
+					{group.questionCount}問
+				</span>
+				<span className="inline-flex items-center rounded-pill border border-border-soft bg-white/80 px-3 py-1 text-xs font-semibold text-base-content shadow-soft">
+					{group.rewardHint}
+				</span>
+			</div>
 		</button>
 	);
 }
@@ -57,6 +68,7 @@ function GroupButton({ group, isSelected, onPress }: { group: IdolGroup; isSelec
 function GroupSelectionPage() {
 	const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
 	const navigate = useNavigate();
+	const selectedGroup = QUIZ_GROUPS.find((group) => group.idolGroupId === selectedGroupId) ?? null;
 
 	const handleContinue = () => {
 		if (!selectedGroupId) return;
@@ -65,20 +77,68 @@ function GroupSelectionPage() {
 	};
 
 	return (
-		<PageShell className="gap-6">
+		<PageShell className="gap-5">
 			<GroupSelectionHeader />
 
-			<div className="flex flex-col gap-3">
-				{MOCK_IDOL_GROUPS.map((group) => (
+			<SectionCard tone="hero" className="px-5 py-5">
+				<div className="flex items-start justify-between gap-3">
+					<div className="space-y-2">
+						<span className="inline-flex items-center gap-2 rounded-pill border border-white/80 bg-white/75 px-3 py-1 text-[0.68rem] font-semibold tracking-[0.18em] text-primary shadow-soft">
+							<Sparkles className="size-3.5" strokeWidth={2.2} />
+							QUICK START
+						</span>
+						<div className="space-y-1">
+							<p className="text-xl font-black tracking-[-0.04em] text-base-content">まずは気分に合うセットをひとつ。</p>
+							<p className="text-sm leading-6 text-muted-foreground">選ぶだけで開始条件がはっきりして、次の導線が迷いません。</p>
+						</div>
+					</div>
+					<div className="rounded-[1.4rem] border border-white/80 bg-white/75 px-4 py-3 text-right shadow-soft">
+						<p className="text-[0.68rem] font-semibold tracking-[0.18em] text-primary">AVAILABLE</p>
+						<p className="mt-1 text-2xl font-black tracking-[-0.04em] text-base-content">{QUIZ_GROUPS.length}</p>
+						<p className="text-xs text-muted-foreground">グループ</p>
+					</div>
+				</div>
+			</SectionCard>
+
+			<div className="grid gap-3 sm:grid-cols-2">
+				{QUIZ_GROUPS.map((group) => (
 					<GroupButton key={group.idolGroupId} group={group} isSelected={selectedGroupId === group.idolGroupId} onPress={setSelectedGroupId} />
 				))}
 			</div>
 
-			<div className="pt-2">
-				<PrimaryCTA className="w-full" disabled={!selectedGroupId} onClick={handleContinue}>
-					問題へ進む
-				</PrimaryCTA>
-			</div>
+			<SectionCard tone="soft" className="px-5 py-5">
+				<div className="space-y-4">
+					<div className="flex items-start gap-3">
+						<div className="flex size-11 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/12 text-primary shadow-soft">
+							<PlayCircle className="size-5" strokeWidth={2.2} />
+						</div>
+						<div className="space-y-1">
+							<p className="text-base font-black tracking-[-0.03em] text-base-content">
+								{selectedGroup ? `${selectedGroup.groupName} セットで挑戦する` : "まずはグループを選ぶ"}
+							</p>
+							<p className="text-sm leading-6 text-muted-foreground">
+								{selectedGroup
+									? `${selectedGroup.questionCount}問でテンポよく進めます。${selectedGroup.rewardHint}`
+									: "選択すると開始ボタンが有効になり、どのセットで始めるかが明確になります。"}
+							</p>
+						</div>
+					</div>
+					{selectedGroup && (
+						<div className="flex flex-wrap gap-2">
+							<span className="inline-flex items-center gap-2 rounded-pill border border-white/80 bg-white/80 px-3 py-1 text-xs font-semibold text-base-content shadow-soft">
+								<Star className="size-3.5 text-primary" strokeWidth={2.2} />
+								{selectedGroup.vibeLabel}
+							</span>
+							<span className="inline-flex items-center rounded-pill border border-white/80 bg-white/80 px-3 py-1 text-xs font-semibold text-base-content shadow-soft">
+								{selectedGroup.rewardHint}
+							</span>
+						</div>
+					)}
+					<PrimaryCTA className="w-full" disabled={!selectedGroupId} onClick={handleContinue}>
+						{selectedGroup ? `${selectedGroup.groupName}でスタート` : "まずはグループを選ぶ"}
+					</PrimaryCTA>
+				</div>
+			</SectionCard>
 		</PageShell>
 	);
 }

--- a/app/v2/src/routes/quiz/question.tsx
+++ b/app/v2/src/routes/quiz/question.tsx
@@ -4,7 +4,7 @@ import { QuizQuestionScreen } from "@/components/quiz/QuizQuestionScreen";
 function QuizQuestionPage() {
 	const navigate = useNavigate();
 
-	return <QuizQuestionScreen onComplete={() => void navigate({ to: "/quiz/result" })} />;
+	return <QuizQuestionScreen groupName="K-POP" onComplete={() => void navigate({ to: "/quiz/result" })} />;
 }
 
 export const Route = createFileRoute("/quiz/question")({

--- a/documents/critics-review-pr-150.md
+++ b/documents/critics-review-pr-150.md
@@ -1,0 +1,37 @@
+# PR #150 チームレビュー懸念点
+
+## 概要
+
+- **PR**: [feat] v2: クイズ導線と回答中UXを再設計する
+- **URL**: https://github.com/Eiji-Kudo/k-drop/pull/150
+- **調査日**: 2026-04-06
+- **レビュー方式**: critics-lite / 手動レビュー
+- **レビュー回数**: 1
+
+## レビュワー構成
+
+- `interaction-state-reviewer`: 回答直後の状態遷移と多重入力耐性を確認
+- `ux-flow-reviewer`: グループ選択から解説表示までの導線のつながりを確認
+
+## 未対応の懸念点
+
+- なし
+
+## 対応済みの懸念点
+
+### HIGH: 回答ボタンの連打で `onAnswer` が二重実行される余地がある
+
+- **検出者**: `interaction-state-reviewer`
+- **対象**: `app/v2/src/components/quiz/ChoicesSection.tsx`
+- **問題点**:
+  `handleSelect` は `selectedIndex` state だけでガードしていたため、最初の state 反映前に別の選択肢を連打すると `onAnswer` が複数回走りうる。これが起きると `QuizQuestionScreen` 側の `correctCount` と `comboCount` が 1 問で複数回更新され、回答直後の score / combo 表示と実際のセッション状態がずれる。
+- **推奨対応**:
+  state 反映を待たずに効く同期ロックを `ref` で持ち、最初のタップで即座に回答処理を閉じる。次の問題へ進むタイミングでロックを解除する。
+- **対応内容**:
+  `selectionLockedRef` を追加し、`handleSelect` の先頭で同期ロックするよう変更した。`handleNext` でロックを解除し、1問につき回答処理が1回だけ走るようにした。
+
+## 最終確認
+
+- **未対応の懸念点**: 0件
+- **対応済みの懸念点**: 1件
+- **新規発見**: なし


### PR DESCRIPTION
## タイトル

[feat] v2: クイズ導線と回答中UXを再設計する

## 関連Issue

- close https://github.com/Eiji-Kudo/k-drop/issues/138

## 関連PR

- なし

## 変更点

- グループ選択画面をカード UI に差し替え、選択状態と開始条件が一目で分かる構成に更新した
- クイズ中ヘッダーに進捗バー、問題数、残り問題数、正解数を追加し、現在位置を把握しやすくした
- 選択肢の状態を `idle / selected / correct / incorrect / dimmed` に分け、押下反応と正誤差分を強めた
- 回答直後のモーダルを score / combo / 残り問題数付きのフィードバックへ刷新し、解説表示と次問題遷移を自然につないだ
- App route test を更新し、グループ選択から結果画面までの導線と回答直後フィードバックを検証できるようにした

## 動作確認事項

- [x] `PATH="/tmp/pnpm10-wrapper:$PATH" corepack pnpm run ci` で test / typecheck / lint / format:check / build が通ることを確認
- [ ] `/quiz` で上部カード群と開始CTAが狭いモバイル高さでも過度に埋もれないことをブラウザで確認
- [ ] `/quiz/$sessionId` で回答後モーダルから解説カード、次問題CTAまでの視線導線が自然なことをブラウザで確認